### PR TITLE
Remember search filter and scroll position in SKMenu

### DIFF
--- a/YotogiShapekeys/MyGUI/UI.cs
+++ b/YotogiShapekeys/MyGUI/UI.cs
@@ -25,6 +25,11 @@ namespace ShapekeyMaster
 		private static bool runonce = true;
 		public static bool changewasmade = false;
 
+		// Used for remembering old values when entering SKMenu
+		private static string oldSKMenuFilter = "";
+		private static Vector2 oldSKMenuScrollPosition = Vector2.zero;
+		private static Vector2 oldPreSKMenuScrollPosition = Vector2.zero;
+
 		private static string Filter = "";
 		private static int FilterMode = 0;
 		private static int Page = 0;
@@ -677,6 +682,9 @@ namespace ShapekeyMaster
 					ShapekeysNameList = HelperClasses.GetAllShapeKeysFromAllMaids().ToList();
 					
 					OpenSKMenu = s.Id;
+					Filter = oldSKMenuFilter;
+					oldPreSKMenuScrollPosition = scrollPosition;
+					scrollPosition = oldSKMenuScrollPosition;
 				}
 
 				s.ShapeKey = GUILayout.TextField(s.ShapeKey, GUILayout.Width(120));
@@ -813,6 +821,9 @@ namespace ShapekeyMaster
 					if (GUILayout.Button("+"))
 					{
 						OpenSKMenu = s.Id;
+						Filter = oldSKMenuFilter;
+						oldPreSKMenuScrollPosition = scrollPosition;
+						scrollPosition = oldSKMenuScrollPosition;
 						ShapekeysNameList = HelperClasses.GetAllShapeKeysFromAllMaids().ToList();
 						ShapekeysNameList.Sort();
 						return;
@@ -932,6 +943,10 @@ namespace ShapekeyMaster
 			if (GUILayout.Button("None"))
 			{
 				OpenSKMenu = Guid.Empty;
+				oldSKMenuFilter = Filter;
+				oldSKMenuScrollPosition = scrollPosition;
+				scrollPosition = oldPreSKMenuScrollPosition;
+
 				s.ShapeKey = "";
 				Filter = "";
 			}
@@ -957,6 +972,9 @@ namespace ShapekeyMaster
 				{
 					OpenSKMenu = Guid.Empty;
 					s.ShapeKey = str;
+					oldSKMenuFilter = Filter;
+					oldSKMenuScrollPosition = scrollPosition;
+					scrollPosition = oldPreSKMenuScrollPosition;
 					Filter = "";
 				}
 			}
@@ -984,6 +1002,9 @@ namespace ShapekeyMaster
 				{
 					OpenSKMenu = Guid.Empty;
 					s.ShapeKey = str;
+					oldSKMenuFilter = Filter;
+					oldSKMenuScrollPosition = scrollPosition;
+					scrollPosition = oldPreSKMenuScrollPosition;
 					Filter = "";
 				}
 			}


### PR DESCRIPTION
Remembers search filter and scroll position when in SKMenu so you don't have to re-type or rescroll everytime when adding multiple shapekeys.

Demo: https://i.gyazo.com/8f8f329b79e6ca759585b9ce98549775.mp4