### PR TITLE
Add various UI user overrides

### DIFF
--- a/ShapekeyMaster/GUI/UI.cs
+++ b/ShapekeyMaster/GUI/UI.cs
@@ -65,9 +65,9 @@ namespace ShapeKeyMaster.GUI
 
 		private static GUIStyle _shineSections;
 		private static GUIStyle _blacklistedButton;
-        //private static GUIStyle PreviewButton;
+		//private static GUIStyle PreviewButton;
 
-        public static void Initialize()
+		public static void Initialize()
 		{
 			//Setup some UI properties.
 			if (_runOnce)
@@ -88,7 +88,7 @@ namespace ShapeKeyMaster.GUI
 					{
 						background = MakeWindowTex(new Color(0.3f, 0.3f, 0.3f, 0.6f), new Color(1, 0, 0, 0.5f))
 					}
-                };
+				};
 
 				_sections = new GUIStyle(UnityEngine.GUI.skin.box)
 				{
@@ -103,7 +103,7 @@ namespace ShapeKeyMaster.GUI
 					{
 						background = MakeTexWithRoundedCorner(new Color(0, 0, 0, 0.6f))
 					}
-                };
+				};
 
 				_shineSections = new GUIStyle(UnityEngine.GUI.skin.box)
 				{
@@ -111,7 +111,7 @@ namespace ShapeKeyMaster.GUI
 					{
 						background = MakeTex(2, 2, new Color(0.92f, 0.74f, 0.2f, 0.3f))
 					}
-                };
+				};
 
 				_blacklistedButton = new GUIStyle(UnityEngine.GUI.skin.button)
 				{
@@ -127,12 +127,12 @@ namespace ShapeKeyMaster.GUI
 					{
 						textColor = Color.red
 					},
-                    fontSize = ShapeKeyMaster.FontSize.Value
-                };
+					fontSize = ShapeKeyMaster.FontSize.Value
+				};
 
-                EntryComparer.Mode = 0;
+				EntryComparer.Mode = 0;
 
-				_runOnce = false;	
+				_runOnce = false;
 			}
 
 			//Sometimes the UI can be improperly sized, this sets it to some measurements.
@@ -146,38 +146,38 @@ namespace ShapeKeyMaster.GUI
 				switch (ShapeKeyMaster.DefaultUIPosition.Value)
 				{
 					case "TopLeft":
-                        uiPosY = 20f;
+						uiPosY = 20f;
 						uiPosX = 20f;
 						break;
-                    case "TopRight":
-                        uiPosY = 20f;
-                        uiPosX = Screen.width - WindowRect.width - 20f;
-                        break;
-                    case "BottomLeft":
-                        uiPosY = Screen.height - WindowRect.height - 20f;
-                        uiPosX = 20f;
-                        break;
-                    case "BottomRight":
-                        uiPosY = Screen.height - WindowRect.height - 20f;
-                        uiPosX = Screen.width - WindowRect.width - 20f;
-                        break;
+					case "TopRight":
+						uiPosY = 20f;
+						uiPosX = Screen.width - WindowRect.width - 20f;
+						break;
+					case "BottomLeft":
+						uiPosY = Screen.height - WindowRect.height - 20f;
+						uiPosX = 20f;
+						break;
+					case "BottomRight":
+						uiPosY = Screen.height - WindowRect.height - 20f;
+						uiPosX = Screen.width - WindowRect.width - 20f;
+						break;
 					case "Center":
 						uiPosY = (Screen.height / 2f) - (WindowRect.height / 2f);
-                        uiPosX = (Screen.width / 2f) - (WindowRect.width / 2f);
+						uiPosX = (Screen.width / 2f) - (WindowRect.width / 2f);
 						break;
 					default:
-                        break;
-                }
+						break;
+				}
 				if (uiPosY < 0 || uiPosX < 0 || uiPosY > Screen.height || uiPosX > Screen.width)
 				{
-                    uiPosY = Screen.height / 4f;
-                    uiPosX = Screen.width / 3f;
+					uiPosY = Screen.height / 4f;
+					uiPosX = Screen.width / 3f;
 				}
 
-                WindowRect.y = uiPosY;
-                WindowRect.x = uiPosX;
+				WindowRect.y = uiPosY;
+				WindowRect.x = uiPosX;
 
-                ShapeKeyMaster.pluginLogger.LogDebug($"Changing sizes of SKM UI to {WindowRect.width} x {WindowRect.height}");
+				ShapeKeyMaster.pluginLogger.LogDebug($"Changing sizes of SKM UI to {WindowRect.width} x {WindowRect.height}");
 
 				_currentHeight = Screen.height;
 				_currentWidth = Screen.width;
@@ -188,7 +188,7 @@ namespace ShapeKeyMaster.GUI
 
 		private static void GuiWindowControls(int windowId)
 		{
-            _closeButton.x = WindowRect.width - (_closeButton.width + 5);
+			_closeButton.x = WindowRect.width - (_closeButton.width + 5);
 			_dragWindow.width = WindowRect.width - (_closeButton.width + 5);
 
 			UnityEngine.GUI.DragWindow(_dragWindow);
@@ -239,17 +239,17 @@ namespace ShapeKeyMaster.GUI
 
 				DisplayHeaderMenu();
 
-                GUILayout.BeginHorizontal();
+				GUILayout.BeginHorizontal();
 
-                ShapeKeyMaster.SimpleMode.Value = GUILayout.Toggle(ShapeKeyMaster.SimpleMode.Value, ShapeKeyMaster.CurrentLanguage["simple"], UIUserOverrides.getToggleStyleOverride());
+				ShapeKeyMaster.SimpleMode.Value = GUILayout.Toggle(ShapeKeyMaster.SimpleMode.Value, ShapeKeyMaster.CurrentLanguage["simple"], UIUserOverrides.getToggleStyleOverride());
 				if (ShapeKeyMaster.SimpleMode.Value)
 				{
 					ShapeKeyMaster.SimpleMode_ShowMoreFuntions.Value = GUILayout.Toggle(ShapeKeyMaster.SimpleMode_ShowMoreFuntions.Value, ShapeKeyMaster.CurrentLanguage["showMoreFuntions"], UIUserOverrides.getToggleStyleOverride());
 				}
 
-                GUILayout.EndHorizontal();
+				GUILayout.EndHorizontal();
 
-                switch (_tabSelection)
+				switch (_tabSelection)
 				{
 					case 1:
 						if (ShapeKeyMaster.SimpleMode.Value)
@@ -260,9 +260,9 @@ namespace ShapeKeyMaster.GUI
 
 							SimpleDisplayShapeKeyEntriesMenu(SkDatabase.GlobalShapekeyDictionary());
 
-                            DisplayPageManager();
+							DisplayPageManager();
 
-                            GUILayout.EndVertical();
+							GUILayout.EndVertical();
 						}
 						else
 						{
@@ -272,16 +272,16 @@ namespace ShapeKeyMaster.GUI
 
 							DisplayShapeKeyEntriesMenu(SkDatabase.GlobalShapekeyDictionary());
 
-                            DisplayPageManager();
+							DisplayPageManager();
 
-                            GUILayout.EndVertical();
+							GUILayout.EndVertical();
 						}
 						break;
 
 					case 2:
 						ShapeKeyMaster.HideInactiveMaids.Value = GUILayout.Toggle(ShapeKeyMaster.HideInactiveMaids.Value, ShapeKeyMaster.CurrentLanguage["hideInactiveMaids"], UIUserOverrides.getToggleStyleOverride());
 
-                        GUILayout.BeginVertical(_sections);
+						GUILayout.BeginVertical(_sections);
 
 						GUILayout.BeginHorizontal(_sections2);
 						GUILayout.FlexibleSpace();
@@ -304,9 +304,9 @@ namespace ShapeKeyMaster.GUI
 
 							SimpleDisplayShapeKeyEntriesMenu(SkDatabase.AllShapekeyDictionary);
 
-                            DisplayPageManager();
+							DisplayPageManager();
 
-                            GUILayout.EndVertical();
+							GUILayout.EndVertical();
 						}
 						else
 						{
@@ -316,9 +316,9 @@ namespace ShapeKeyMaster.GUI
 
 							DisplayShapeKeyEntriesMenu(SkDatabase.AllShapekeyDictionary);
 
-                            DisplayPageManager();
+							DisplayPageManager();
 
-                            GUILayout.EndVertical();
+							GUILayout.EndVertical();
 						}
 						break;
 				}
@@ -332,7 +332,7 @@ namespace ShapeKeyMaster.GUI
 
 		private static void DisplayHeaderMenu()
 		{
-            GUILayout.BeginHorizontal(_sections2);
+			GUILayout.BeginHorizontal(_sections2);
 
 			var modeLabel = EntryComparer.Mode == 0 ? ShapeKeyMaster.CurrentLanguage["date"] : EntryComparer.Mode == 1 ? ShapeKeyMaster.CurrentLanguage["name"] : EntryComparer.Mode == 2 ? ShapeKeyMaster.CurrentLanguage["shapekey"] : "GUID";
 			var ascendLabel = EntryComparer.Ascending ? "↑" : "↓";
@@ -372,7 +372,7 @@ namespace ShapeKeyMaster.GUI
 
 		private static void DisplaySearchMenu(bool noModes = false)
 		{
-            GUILayout.BeginHorizontal(_sections2);
+			GUILayout.BeginHorizontal(_sections2);
 
 			if (_openSkMenu != Guid.Empty)
 			{
@@ -417,7 +417,7 @@ namespace ShapeKeyMaster.GUI
 
 		private static void DisplayPageManager(string maidWithKey = null)
 		{
-            string headerString;
+			string headerString;
 			int applicantCount;
 
 			switch (_tabSelection)
@@ -458,7 +458,7 @@ namespace ShapeKeyMaster.GUI
 
 		private static void DisplayFooter()
 		{
-            GUILayout.BeginVertical(_sections2);
+			GUILayout.BeginVertical(_sections2);
 			if (_exportMenuOpen)
 			{
 				if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["cancel"], UIUserOverrides.getButtonStyleOverride()))
@@ -510,7 +510,7 @@ namespace ShapeKeyMaster.GUI
 
 		private static void DisplayMaidOptions()
 		{
-            GUILayout.BeginVertical(_sections);
+			GUILayout.BeginVertical(_sections);
 
 			foreach (var maidWithKey in SkDatabase.ListOfMaidsWithKeys().OrderBy(maid => maid))
 			{
@@ -569,7 +569,7 @@ namespace ShapeKeyMaster.GUI
 					do
 					{
 						tempMaidGroupName = "Temporary Maid Group Name" + rand.Next();
-					} 
+					}
 					while (SkDatabase.ShapeKeysByMaid(tempMaidGroupName).Count > 0);
 
 					foreach (var key in newKeys)
@@ -656,8 +656,8 @@ namespace ShapeKeyMaster.GUI
 
 					GUILayout.EndHorizontal();
 
-                    DisplayPageManager(maidWithKey);
-                }
+					DisplayPageManager(maidWithKey);
+				}
 
 				GUILayout.EndVertical();
 			}
@@ -676,7 +676,7 @@ namespace ShapeKeyMaster.GUI
 
 		private static void SimpleDisplayShapeKeyEntriesMenu(Dictionary<Guid, ShapeKeyEntry> givenShapeKeys)
 		{
-            var filteredKeys = givenShapeKeys.Values
+			var filteredKeys = givenShapeKeys.Values
 				.Where(s => string.IsNullOrEmpty(_filter) ||
 							(_filterMode == 0 && s.EntryName.Contains(_filter, StringComparison.OrdinalIgnoreCase)) ||
 							(_filterMode == 1 && s.Maid.Contains(_filter, StringComparison.OrdinalIgnoreCase)) ||
@@ -721,12 +721,12 @@ namespace ShapeKeyMaster.GUI
 				s.Deform = Mathf.RoundToInt(HorizontalSliderWithInputBox(s.Deform, 0, ShapeKeyMaster.MaxDeform.Value));
 				if (!ShapeKeyMaster.SimpleMode_ShowMoreFuntions.Value)
 				{
-                    if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["delete"], UIUserOverrides.getButtonStyleOverride()))
-                    {
-                        SkDatabase.Remove(s);
-                    }
-                }
-                GUILayout.EndHorizontal();
+					if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["delete"], UIUserOverrides.getButtonStyleOverride()))
+					{
+						SkDatabase.Remove(s);
+					}
+				}
+				GUILayout.EndHorizontal();
 
 				if (ShapeKeyMaster.SimpleMode_ShowMoreFuntions.Value)
 				{
@@ -762,7 +762,7 @@ namespace ShapeKeyMaster.GUI
 			if (_tabSelection != 2 && GUILayout.Button("+", UIUserOverrides.getButtonStyleOverride(), GUILayout.Width(40)))
 			{
 #if (DEBUG)
-        ShapeKeyMaster.pluginLogger.LogDebug("I've been clicked! Oh the humanity!!");
+				ShapeKeyMaster.pluginLogger.LogDebug("I've been clicked! Oh the humanity!!");
 #endif
 				var activeGuid = Guid.NewGuid();
 				SkDatabase.Add(new ShapeKeyEntry(activeGuid));
@@ -899,7 +899,7 @@ namespace ShapeKeyMaster.GUI
 
 		private static void DisplayShapeKeyEntriesMenu(Dictionary<Guid, ShapeKeyEntry> givenShapeKeys)
 		{
-            if (_tabSelection != 2 && GUILayout.Button(ShapeKeyMaster.CurrentLanguage["addNewShapekey"], UIUserOverrides.getButtonStyleOverride()))
+			if (_tabSelection != 2 && GUILayout.Button(ShapeKeyMaster.CurrentLanguage["addNewShapekey"], UIUserOverrides.getButtonStyleOverride()))
 			{
 #if (DEBUG)
 				ShapeKeyMaster.pluginLogger.LogDebug("I've been clicked! Oh the humanity!!");
@@ -915,9 +915,9 @@ namespace ShapeKeyMaster.GUI
 
 			var filteredKeys = givenShapeKeys.Values
 				.Where(s => string.IsNullOrEmpty(_filter) ||
-				            (_filterMode == 0 && s.EntryName.Contains(_filter, StringComparison.OrdinalIgnoreCase)) ||
-				            (_filterMode == 1 && s.Maid.Contains(_filter, StringComparison.OrdinalIgnoreCase)) ||
-				            (_filterMode == 2 && s.ShapeKey.Contains(_filter, StringComparison.OrdinalIgnoreCase)))
+							(_filterMode == 0 && s.EntryName.Contains(_filter, StringComparison.OrdinalIgnoreCase)) ||
+							(_filterMode == 1 && s.Maid.Contains(_filter, StringComparison.OrdinalIgnoreCase)) ||
+							(_filterMode == 2 && s.ShapeKey.Contains(_filter, StringComparison.OrdinalIgnoreCase)))
 				.OrderBy(s => s, EntryComparer);
 
 			foreach (var s in filteredKeys.Skip(_page).Take(ShapeKeyMaster.EntriesPerPage.Value))
@@ -1085,7 +1085,7 @@ namespace ShapeKeyMaster.GUI
 		//From here on down are submenus....
 		private static void DisplayShapeKeySelectMenu(ShapeKeyEntry s)
 		{
-            DisplaySearchMenu(true);
+			DisplaySearchMenu(true);
 
 			GUILayout.BeginHorizontal();
 
@@ -1228,7 +1228,7 @@ namespace ShapeKeyMaster.GUI
 
 		private static void DisplayMaidSelectMenu(ShapeKeyEntry s)
 		{
-            DisplaySearchMenu(true);
+			DisplaySearchMenu(true);
 
 			GUILayout.Label($"{s.EntryName} {ShapeKeyMaster.CurrentLanguage["selectMaid"]}", UIUserOverrides.getLabelStyleOverride());
 
@@ -1271,7 +1271,7 @@ namespace ShapeKeyMaster.GUI
 
 		private static void DisplayMaidGroupCreateMenu(Dictionary<Guid, ShapeKeyEntry> givenShapeKeys)
 		{
-            DisplaySearchMenu(true);
+			DisplaySearchMenu(true);
 
 			GUILayout.Label(ShapeKeyMaster.CurrentLanguage["selectNewMaidGroup"], UIUserOverrides.getLabelStyleOverride());
 
@@ -1321,7 +1321,7 @@ namespace ShapeKeyMaster.GUI
 
 		private static void DisplayRenameMenu(ShapeKeyEntry s)
 		{
-            GUILayout.Label($"{ShapeKeyMaster.CurrentLanguage["nowRenaming"]} {s.EntryName}", UIUserOverrides.getLabelStyleOverride());
+			GUILayout.Label($"{ShapeKeyMaster.CurrentLanguage["nowRenaming"]} {s.EntryName}", UIUserOverrides.getLabelStyleOverride());
 
 			s.EntryName = GUILayout.TextField(s.EntryName, UIUserOverrides.getTextFieldStyleOverride());
 
@@ -1333,7 +1333,7 @@ namespace ShapeKeyMaster.GUI
 
 		private static void DisplaySlotConditionsMenu(ShapeKeyEntry s)
 		{
-            GUILayout.BeginVertical(_sections);
+			GUILayout.BeginVertical(_sections);
 
 			GUILayout.BeginHorizontal(_sections2);
 			GUILayout.FlexibleSpace();
@@ -1440,7 +1440,7 @@ namespace ShapeKeyMaster.GUI
 
 		private static void DisplayMaidRenameMenu(string s)
 		{
-            DisplaySearchMenu(true);
+			DisplaySearchMenu(true);
 
 			GUILayout.Label($"{ShapeKeyMaster.CurrentLanguage["renamingMaidGroup"]}: {s}", UIUserOverrides.getLabelStyleOverride());
 
@@ -1494,7 +1494,7 @@ namespace ShapeKeyMaster.GUI
 
 		private static void DisplayExportMenu()
 		{
-            ShapeKeyMaster.HideInactiveMaids.Value = GUILayout.Toggle(ShapeKeyMaster.HideInactiveMaids.Value, ShapeKeyMaster.CurrentLanguage["hideInactiveMaids"], UIUserOverrides.getToggleStyleOverride());
+			ShapeKeyMaster.HideInactiveMaids.Value = GUILayout.Toggle(ShapeKeyMaster.HideInactiveMaids.Value, ShapeKeyMaster.CurrentLanguage["hideInactiveMaids"], UIUserOverrides.getToggleStyleOverride());
 
 			if (ShapeKeyMaster.HideInactiveMaids.Value == false && GUILayout.Button(ShapeKeyMaster.CurrentLanguage["all"], UIUserOverrides.getButtonStyleOverride()))
 			{

--- a/ShapekeyMaster/GUI/UI.cs
+++ b/ShapekeyMaster/GUI/UI.cs
@@ -65,9 +65,9 @@ namespace ShapeKeyMaster.GUI
 
 		private static GUIStyle _shineSections;
 		private static GUIStyle _blacklistedButton;
-		//private static GUIStyle PreviewButton;
+        //private static GUIStyle PreviewButton;
 
-		public static void Initialize()
+        public static void Initialize()
 		{
 			//Setup some UI properties.
 			if (_runOnce)
@@ -88,7 +88,7 @@ namespace ShapeKeyMaster.GUI
 					{
 						background = MakeWindowTex(new Color(0.3f, 0.3f, 0.3f, 0.6f), new Color(1, 0, 0, 0.5f))
 					}
-				};
+                };
 
 				_sections = new GUIStyle(UnityEngine.GUI.skin.box)
 				{
@@ -103,7 +103,7 @@ namespace ShapeKeyMaster.GUI
 					{
 						background = MakeTexWithRoundedCorner(new Color(0, 0, 0, 0.6f))
 					}
-				};
+                };
 
 				_shineSections = new GUIStyle(UnityEngine.GUI.skin.box)
 				{
@@ -111,7 +111,7 @@ namespace ShapeKeyMaster.GUI
 					{
 						background = MakeTex(2, 2, new Color(0.92f, 0.74f, 0.2f, 0.3f))
 					}
-				};
+                };
 
 				_blacklistedButton = new GUIStyle(UnityEngine.GUI.skin.button)
 				{
@@ -126,24 +126,58 @@ namespace ShapeKeyMaster.GUI
 					active =
 					{
 						textColor = Color.red
-					}
-				};
+					},
+                    fontSize = ShapeKeyMaster.FontSize.Value
+                };
 
-				EntryComparer.Mode = 0;
+                EntryComparer.Mode = 0;
 
-				_runOnce = false;
+				_runOnce = false;	
 			}
 
 			//Sometimes the UI can be improperly sized, this sets it to some measurements.
 			if (_currentHeight != Screen.height || _currentWidth != Screen.width)
 			{
-				WindowRect.height = Math.Max(Screen.height / 1.5f, 200);
-				WindowRect.width = Math.Max(Screen.width / 3f, 500);
+				WindowRect.height = Math.Max(Screen.height / 1.5f, ShapeKeyMaster.MinUIHeight.Value);
+				WindowRect.width = Math.Max(Screen.width / 3f, ShapeKeyMaster.MinUIWidth.Value);
 
-				WindowRect.y = Screen.height / 4f;
-				WindowRect.x = Screen.width / 3f;
+				float uiPosY = Screen.height / 4f;
+				float uiPosX = Screen.width / 3f;
+				switch (ShapeKeyMaster.DefaultUIPosition.Value)
+				{
+					case "TopLeft":
+                        uiPosY = 20f;
+						uiPosX = 20f;
+						break;
+                    case "TopRight":
+                        uiPosY = 20f;
+                        uiPosX = Screen.width - WindowRect.width - 20f;
+                        break;
+                    case "BottomLeft":
+                        uiPosY = Screen.height - WindowRect.height - 20f;
+                        uiPosX = 20f;
+                        break;
+                    case "BottomRight":
+                        uiPosY = Screen.height - WindowRect.height - 20f;
+                        uiPosX = Screen.width - WindowRect.width - 20f;
+                        break;
+					case "Center":
+						uiPosY = (Screen.height / 2f) - (WindowRect.height / 2f);
+                        uiPosX = (Screen.width / 2f) - (WindowRect.width / 2f);
+						break;
+					default:
+                        break;
+                }
+				if (uiPosY < 0 || uiPosX < 0 || uiPosY > Screen.height || uiPosX > Screen.width)
+				{
+                    uiPosY = Screen.height / 4f;
+                    uiPosX = Screen.width / 3f;
+				}
 
-				ShapeKeyMaster.pluginLogger.LogDebug($"Changing sizes of SKM UI to {WindowRect.width} x {WindowRect.height}");
+                WindowRect.y = uiPosY;
+                WindowRect.x = uiPosX;
+
+                ShapeKeyMaster.pluginLogger.LogDebug($"Changing sizes of SKM UI to {WindowRect.width} x {WindowRect.height}");
 
 				_currentHeight = Screen.height;
 				_currentWidth = Screen.width;
@@ -154,7 +188,7 @@ namespace ShapeKeyMaster.GUI
 
 		private static void GuiWindowControls(int windowId)
 		{
-			_closeButton.x = WindowRect.width - (_closeButton.width + 5);
+            _closeButton.x = WindowRect.width - (_closeButton.width + 5);
 			_dragWindow.width = WindowRect.width - (_closeButton.width + 5);
 
 			UnityEngine.GUI.DragWindow(_dragWindow);
@@ -205,9 +239,17 @@ namespace ShapeKeyMaster.GUI
 
 				DisplayHeaderMenu();
 
-				ShapeKeyMaster.SimpleMode.Value = GUILayout.Toggle(ShapeKeyMaster.SimpleMode.Value, ShapeKeyMaster.CurrentLanguage["simple"]);
+                GUILayout.BeginHorizontal();
 
-				switch (_tabSelection)
+                ShapeKeyMaster.SimpleMode.Value = GUILayout.Toggle(ShapeKeyMaster.SimpleMode.Value, ShapeKeyMaster.CurrentLanguage["simple"], UIUserOverrides.getToggleStyleOverride());
+				if (ShapeKeyMaster.SimpleMode.Value)
+				{
+					ShapeKeyMaster.SimpleMode_ShowMoreFuntions.Value = GUILayout.Toggle(ShapeKeyMaster.SimpleMode_ShowMoreFuntions.Value, ShapeKeyMaster.CurrentLanguage["showMoreFuntions"], UIUserOverrides.getToggleStyleOverride());
+				}
+
+                GUILayout.EndHorizontal();
+
+                switch (_tabSelection)
 				{
 					case 1:
 						if (ShapeKeyMaster.SimpleMode.Value)
@@ -218,7 +260,9 @@ namespace ShapeKeyMaster.GUI
 
 							SimpleDisplayShapeKeyEntriesMenu(SkDatabase.GlobalShapekeyDictionary());
 
-							GUILayout.EndVertical();
+                            DisplayPageManager();
+
+                            GUILayout.EndVertical();
 						}
 						else
 						{
@@ -228,18 +272,20 @@ namespace ShapeKeyMaster.GUI
 
 							DisplayShapeKeyEntriesMenu(SkDatabase.GlobalShapekeyDictionary());
 
-							GUILayout.EndVertical();
+                            DisplayPageManager();
+
+                            GUILayout.EndVertical();
 						}
 						break;
 
 					case 2:
-						ShapeKeyMaster.HideInactiveMaids.Value = GUILayout.Toggle(ShapeKeyMaster.HideInactiveMaids.Value, ShapeKeyMaster.CurrentLanguage["hideInactiveMaids"]);
+						ShapeKeyMaster.HideInactiveMaids.Value = GUILayout.Toggle(ShapeKeyMaster.HideInactiveMaids.Value, ShapeKeyMaster.CurrentLanguage["hideInactiveMaids"], UIUserOverrides.getToggleStyleOverride());
 
-						GUILayout.BeginVertical(_sections);
+                        GUILayout.BeginVertical(_sections);
 
 						GUILayout.BeginHorizontal(_sections2);
 						GUILayout.FlexibleSpace();
-						GUILayout.Label(ShapeKeyMaster.CurrentLanguage["maids"]);
+						GUILayout.Label(ShapeKeyMaster.CurrentLanguage["maids"], UIUserOverrides.getLabelStyleOverride());
 						GUILayout.FlexibleSpace();
 						GUILayout.EndHorizontal();
 
@@ -258,7 +304,9 @@ namespace ShapeKeyMaster.GUI
 
 							SimpleDisplayShapeKeyEntriesMenu(SkDatabase.AllShapekeyDictionary);
 
-							GUILayout.EndVertical();
+                            DisplayPageManager();
+
+                            GUILayout.EndVertical();
 						}
 						else
 						{
@@ -268,7 +316,9 @@ namespace ShapeKeyMaster.GUI
 
 							DisplayShapeKeyEntriesMenu(SkDatabase.AllShapekeyDictionary);
 
-							GUILayout.EndVertical();
+                            DisplayPageManager();
+
+                            GUILayout.EndVertical();
 						}
 						break;
 				}
@@ -282,34 +332,34 @@ namespace ShapeKeyMaster.GUI
 
 		private static void DisplayHeaderMenu()
 		{
-			GUILayout.BeginHorizontal(_sections2);
+            GUILayout.BeginHorizontal(_sections2);
 
 			var modeLabel = EntryComparer.Mode == 0 ? ShapeKeyMaster.CurrentLanguage["date"] : EntryComparer.Mode == 1 ? ShapeKeyMaster.CurrentLanguage["name"] : EntryComparer.Mode == 2 ? ShapeKeyMaster.CurrentLanguage["shapekey"] : "GUID";
 			var ascendLabel = EntryComparer.Ascending ? "↑" : "↓";
 
-			GUILayout.Label(ShapeKeyMaster.CurrentLanguage["sortBy"] + ":");
-			if (GUILayout.Button(modeLabel))
+			GUILayout.Label(ShapeKeyMaster.CurrentLanguage["sortBy"] + ":", UIUserOverrides.getLabelStyleOverride());
+			if (GUILayout.Button(modeLabel, UIUserOverrides.getButtonStyleOverride()))
 			{
 				++EntryComparer.Mode;
 			}
-			if (GUILayout.Button(ascendLabel))
+			if (GUILayout.Button(ascendLabel, UIUserOverrides.getButtonStyleOverride()))
 			{
 				EntryComparer.Ascending = !EntryComparer.Ascending;
 			}
 
 			GUILayout.FlexibleSpace();
 
-			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["all"]))
+			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["all"], UIUserOverrides.getButtonStyleOverride()))
 			{
 				_page = 0;
 				_tabSelection = 0;
 			}
-			else if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["globals"]))
+			else if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["globals"], UIUserOverrides.getButtonStyleOverride()))
 			{
 				_page = 0;
 				_tabSelection = 1;
 			}
-			else if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["maids"]))
+			else if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["maids"], UIUserOverrides.getButtonStyleOverride()))
 			{
 				_page = 0;
 				_tabSelection = 2;
@@ -322,52 +372,52 @@ namespace ShapeKeyMaster.GUI
 
 		private static void DisplaySearchMenu(bool noModes = false)
 		{
-			GUILayout.BeginHorizontal(_sections2);
+            GUILayout.BeginHorizontal(_sections2);
 
 			if (_openSkMenu != Guid.Empty)
 			{
-				_filterCommonKeys = GUILayout.Toggle(_filterCommonKeys, ShapeKeyMaster.CurrentLanguage["filterCommonKeys"]);
+				_filterCommonKeys = GUILayout.Toggle(_filterCommonKeys, ShapeKeyMaster.CurrentLanguage["filterCommonKeys"], UIUserOverrides.getToggleStyleOverride());
 
-				_hideBlacklistedKeys = GUILayout.Toggle(_hideBlacklistedKeys, ShapeKeyMaster.CurrentLanguage["hideBlacklistedKeys"]);
+				_hideBlacklistedKeys = GUILayout.Toggle(_hideBlacklistedKeys, ShapeKeyMaster.CurrentLanguage["hideBlacklistedKeys"], UIUserOverrides.getToggleStyleOverride());
 			}
 
 			GUILayout.FlexibleSpace();
 
-			GUILayout.Label(ShapeKeyMaster.CurrentLanguage["searchBy"] + ":");
+			GUILayout.Label(ShapeKeyMaster.CurrentLanguage["searchBy"] + ":", UIUserOverrides.getLabelStyleOverride());
 
 			if (noModes == false)
 			{
 				if (_filterMode == 0)
 				{
-					if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["name"]))
+					if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["name"], UIUserOverrides.getButtonStyleOverride()))
 					{
 						_filterMode = 1;
 					}
 				}
 				else if (_filterMode == 1)
 				{
-					if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["maid"]))
+					if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["maid"], UIUserOverrides.getButtonStyleOverride()))
 					{
 						_filterMode = 2;
 					}
 				}
 				else if (_filterMode == 2)
 				{
-					if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["shapekey"]))
+					if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["shapekey"], UIUserOverrides.getButtonStyleOverride()))
 					{
 						_filterMode = 0;
 					}
 				}
 			}
 
-			_filter = GUILayout.TextField(_filter, GUILayout.Width(160));
+			_filter = GUILayout.TextField(_filter, UIUserOverrides.getTextFieldStyleOverride(), GUILayout.Width(160));
 
 			GUILayout.EndHorizontal();
 		}
 
 		private static void DisplayPageManager(string maidWithKey = null)
 		{
-			string headerString;
+            string headerString;
 			int applicantCount;
 
 			switch (_tabSelection)
@@ -389,14 +439,14 @@ namespace ShapeKeyMaster.GUI
 			}
 
 			GUILayout.BeginHorizontal(_sections2);
-			if (GUILayout.Button("<<"))
+			if (GUILayout.Button("<<", UIUserOverrides.getButtonStyleOverride()))
 			{
 				_page = Math.Max(_page - ShapeKeyMaster.EntriesPerPage.Value, 0);
 			}
 			GUILayout.FlexibleSpace();
-			GUILayout.Label($"{headerString}:{_page} ~ {_page + ShapeKeyMaster.EntriesPerPage.Value}");
+			GUILayout.Label($"{headerString}:{_page} ~ {_page + ShapeKeyMaster.EntriesPerPage.Value}", UIUserOverrides.getLabelStyleOverride());
 			GUILayout.FlexibleSpace();
-			if (GUILayout.Button(">>"))
+			if (GUILayout.Button(">>", UIUserOverrides.getButtonStyleOverride()))
 			{
 				if (_page + ShapeKeyMaster.EntriesPerPage.Value < applicantCount)
 				{
@@ -408,10 +458,10 @@ namespace ShapeKeyMaster.GUI
 
 		private static void DisplayFooter()
 		{
-			GUILayout.BeginVertical(_sections2);
+            GUILayout.BeginVertical(_sections2);
 			if (_exportMenuOpen)
 			{
-				if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["cancel"]))
+				if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["cancel"], UIUserOverrides.getButtonStyleOverride()))
 				{
 					_exportMenuOpen = false;
 				}
@@ -419,7 +469,7 @@ namespace ShapeKeyMaster.GUI
 			else
 			{
 				GUILayout.BeginHorizontal();
-				if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["reload"]))
+				if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["reload"], UIUserOverrides.getButtonStyleOverride()))
 				{
 					_openSkMenu = Guid.Empty;
 					_openMaidMenu = Guid.Empty;
@@ -433,7 +483,7 @@ namespace ShapeKeyMaster.GUI
 
 					return;
 				}
-				if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["save"]))
+				if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["save"], UIUserOverrides.getButtonStyleOverride()))
 				{
 #if (DEBUG)
 					ShapeKeyMaster.pluginLogger.LogDebug("Saving data to configs now!");
@@ -443,11 +493,11 @@ namespace ShapeKeyMaster.GUI
 				}
 				GUILayout.EndHorizontal();
 				GUILayout.BeginHorizontal();
-				if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["export"]))
+				if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["export"], UIUserOverrides.getButtonStyleOverride()))
 				{
 					_exportMenuOpen = true;
 				}
-				if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["import"]))
+				if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["import"], UIUserOverrides.getButtonStyleOverride()))
 				{
 					SkDatabase.ConcatenateDictionary(ShapeKeyMaster.LoadFromJson(null, true).AllShapekeyDictionary);
 
@@ -460,7 +510,7 @@ namespace ShapeKeyMaster.GUI
 
 		private static void DisplayMaidOptions()
 		{
-			GUILayout.BeginVertical(_sections);
+            GUILayout.BeginVertical(_sections);
 
 			foreach (var maidWithKey in SkDatabase.ListOfMaidsWithKeys().OrderBy(maid => maid))
 			{
@@ -485,9 +535,9 @@ namespace ShapeKeyMaster.GUI
 
 				GUILayout.BeginVertical(_sections);
 				GUILayout.BeginHorizontal(_sections);
-				GUILayout.Label(maidWithKey);
+				GUILayout.Label(maidWithKey, UIUserOverrides.getLabelStyleOverride());
 
-				if (GUILayout.Button("I/O"))
+				if (GUILayout.Button("I/O", UIUserOverrides.getButtonStyleOverride()))
 				{
 					ShapeKeyEntry first = null;
 					foreach (var value in SkDatabase.ShapeKeysByMaid(maidWithKey).Values)
@@ -506,7 +556,7 @@ namespace ShapeKeyMaster.GUI
 					return;
 				}
 
-				if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["copy_to"]))
+				if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["copy_to"], UIUserOverrides.getButtonStyleOverride()))
 				{
 					var keysToCopy = SkDatabase.ShapeKeysByMaid(maidWithKey).Values;
 					var newKeys = keysToCopy.Select(r => r.Clone() as ShapeKeyEntry).ToDictionary(r => r.Id, m => m);
@@ -537,7 +587,7 @@ namespace ShapeKeyMaster.GUI
 					return;
 				}
 
-				if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["rename"]))
+				if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["rename"], UIUserOverrides.getButtonStyleOverride()))
 				{
 					_maidGroupRenameMenu = maidWithKey;
 					_maidGroupRename = _maidGroupRenameMenu;
@@ -547,7 +597,7 @@ namespace ShapeKeyMaster.GUI
 					return;
 				}
 
-				if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["delete"]))
+				if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["delete"], UIUserOverrides.getButtonStyleOverride()))
 				{
 					foreach (var skp in SkDatabase.ShapeKeysByMaid(maidWithKey).Values)
 					{
@@ -559,7 +609,7 @@ namespace ShapeKeyMaster.GUI
 
 				GUILayout.FlexibleSpace();
 
-				if (GUILayout.Button("☰"))
+				if (GUILayout.Button("☰", UIUserOverrides.getButtonStyleOverride()))
 				{
 					if (!_maidSelection.Contains(maidWithKey))
 					{
@@ -592,7 +642,7 @@ namespace ShapeKeyMaster.GUI
 
 					GUILayout.BeginHorizontal();
 
-					if (GUILayout.Button("+", GUILayout.Width(40)))
+					if (GUILayout.Button("+", UIUserOverrides.getButtonStyleOverride(), GUILayout.Width(40)))
 					{
 						var id = Guid.NewGuid();
 						SkDatabase.Add(new ShapeKeyEntry(id, maidWithKey));
@@ -605,12 +655,14 @@ namespace ShapeKeyMaster.GUI
 					GUILayout.FlexibleSpace();
 
 					GUILayout.EndHorizontal();
-				}
+
+                    DisplayPageManager(maidWithKey);
+                }
 
 				GUILayout.EndVertical();
 			}
 
-			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["newMaidGroup"]))
+			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["newMaidGroup"], UIUserOverrides.getButtonStyleOverride()))
 			{
 				_maidNameList = Extensions.GetNameOfAllMaids().ToList();
 
@@ -624,7 +676,7 @@ namespace ShapeKeyMaster.GUI
 
 		private static void SimpleDisplayShapeKeyEntriesMenu(Dictionary<Guid, ShapeKeyEntry> givenShapeKeys)
 		{
-			var filteredKeys = givenShapeKeys.Values
+            var filteredKeys = givenShapeKeys.Values
 				.Where(s => string.IsNullOrEmpty(_filter) ||
 							(_filterMode == 0 && s.EntryName.Contains(_filter, StringComparison.OrdinalIgnoreCase)) ||
 							(_filterMode == 1 && s.Maid.Contains(_filter, StringComparison.OrdinalIgnoreCase)) ||
@@ -639,12 +691,12 @@ namespace ShapeKeyMaster.GUI
 
 				GUILayout.BeginHorizontal();
 				var status = s.Enabled == 0 ? "ignore" : (s.Enabled == 1 ? "zero" : "on");
-				if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage[status], GUILayout.MaxWidth(60)))
+				if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage[status], UIUserOverrides.getButtonStyleOverride()))
 				{
 					s.Enabled -= 1;
 				}
 
-				if (GUILayout.Button("+", GUILayout.Width(30)))
+				if (GUILayout.Button("+", UIUserOverrides.getButtonStyleOverride(), GUILayout.Width(30)))
 				{
 					if (string.IsNullOrEmpty(s.Maid))
 					{
@@ -665,38 +717,49 @@ namespace ShapeKeyMaster.GUI
 					_oldPreSkMenuScrollPosition = _scrollPosition;
 					_scrollPosition = _oldSkMenuScrollPosition;
 				}
-				s.ShapeKey = GUILayout.TextField(s.ShapeKey, GUILayout.Width(120));
+				s.ShapeKey = GUILayout.TextField(s.ShapeKey, UIUserOverrides.getTextFieldStyleOverride(), GUILayout.Width(ShapeKeyMaster.MinShapekeyNameTextboxWidth.Value));
 				s.Deform = Mathf.RoundToInt(HorizontalSliderWithInputBox(s.Deform, 0, ShapeKeyMaster.MaxDeform.Value));
-				GUILayout.EndHorizontal();
+				if (!ShapeKeyMaster.SimpleMode_ShowMoreFuntions.Value)
+				{
+                    if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["delete"], UIUserOverrides.getButtonStyleOverride()))
+                    {
+                        SkDatabase.Remove(s);
+                    }
+                }
+                GUILayout.EndHorizontal();
 
-				GUILayout.BeginHorizontal(style);
-				if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["openSlotCondMenu"], GUILayout.MaxWidth(80)))
+				if (ShapeKeyMaster.SimpleMode_ShowMoreFuntions.Value)
 				{
-					_openSlotConditions = s.Id;
+					GUILayout.BeginHorizontal(style);
+					if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["openSlotCondMenu"], UIUserOverrides.getButtonStyleOverride()))
+					{
+						_openSlotConditions = s.Id;
+					}
+					s.ConditionalsToggle = GUILayout.Toggle(s.ConditionalsToggle, ShapeKeyMaster.CurrentLanguage["enableConditionals"], UIUserOverrides.getToggleStyleOverride());
+					var cateNameLabel = !string.IsNullOrEmpty(s.EntryName) ? s.EntryName : "";
+					cateNameLabel += _tabSelection == 0 && !string.IsNullOrEmpty(cateNameLabel) ? " | " : "";
+					cateNameLabel += _tabSelection == 0 ? string.IsNullOrEmpty(s.Maid) ? ShapeKeyMaster.CurrentLanguage["global"] : s.Maid : "";
+					cateNameLabel = cateNameLabel.Length > 25 ? cateNameLabel.Substring(0, 25) + "..." : cateNameLabel;
+					GUILayout.Label(cateNameLabel, UIUserOverrides.getLabelStyleOverride());
+					GUILayout.FlexibleSpace();
+					if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["copy"], UIUserOverrides.getButtonStyleOverride()))
+					{
+						var newEntry = s.Clone() as ShapeKeyEntry;
+						newEntry.EntryName += "(Copy)";
+						SkDatabase.Add(newEntry);
+						FocusToNewKey(newEntry.Id, givenShapeKeys);
+					}
+					if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["delete"], UIUserOverrides.getButtonStyleOverride()))
+					{
+						SkDatabase.Remove(s);
+					}
+					GUILayout.EndHorizontal();
 				}
-				s.ConditionalsToggle = GUILayout.Toggle(s.ConditionalsToggle, ShapeKeyMaster.CurrentLanguage["enableConditionals"]);
-				var cateNameLabel = !string.IsNullOrEmpty(s.EntryName) ? s.EntryName : "";
-				cateNameLabel += _tabSelection == 0 && !string.IsNullOrEmpty(cateNameLabel) ? " | " : "";
-				cateNameLabel += _tabSelection == 0 ? string.IsNullOrEmpty(s.Maid) ? ShapeKeyMaster.CurrentLanguage["global"] : s.Maid : "";
-				cateNameLabel = cateNameLabel.Length > 25 ? cateNameLabel.Substring(0, 25) + "..." : cateNameLabel;
-				GUILayout.Label(cateNameLabel);
-				if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["copy"], GUILayout.MaxWidth(60)))
-				{
-					var newEntry = s.Clone() as ShapeKeyEntry;
-					newEntry.EntryName += "(Copy)";
-					SkDatabase.Add(newEntry);
-					FocusToNewKey(newEntry.Id, givenShapeKeys);
-				}
-				if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["delete"], GUILayout.MaxWidth(40)))
-				{
-					SkDatabase.Remove(s);
-				}
-				GUILayout.EndHorizontal();
 
 				GUILayout.EndVertical();
 			}
 
-			if (_tabSelection != 2 && GUILayout.Button("+", GUILayout.Width(40)))
+			if (_tabSelection != 2 && GUILayout.Button("+", UIUserOverrides.getButtonStyleOverride(), GUILayout.Width(40)))
 			{
 #if (DEBUG)
         ShapeKeyMaster.pluginLogger.LogDebug("I've been clicked! Oh the humanity!!");
@@ -836,7 +899,7 @@ namespace ShapeKeyMaster.GUI
 
 		private static void DisplayShapeKeyEntriesMenu(Dictionary<Guid, ShapeKeyEntry> givenShapeKeys)
 		{
-			if (_tabSelection != 2 && GUILayout.Button(ShapeKeyMaster.CurrentLanguage["addNewShapekey"]))
+            if (_tabSelection != 2 && GUILayout.Button(ShapeKeyMaster.CurrentLanguage["addNewShapekey"], UIUserOverrides.getButtonStyleOverride()))
 			{
 #if (DEBUG)
 				ShapeKeyMaster.pluginLogger.LogDebug("I've been clicked! Oh the humanity!!");
@@ -866,32 +929,32 @@ namespace ShapeKeyMaster.GUI
 				if (s.Collapsed == false)
 				{
 					GUILayout.BeginHorizontal(style);
-					GUILayout.Label(s.EntryName);
+					GUILayout.Label(s.EntryName, UIUserOverrides.getLabelStyleOverride());
 					GUILayout.FlexibleSpace();
-					if (GUILayout.Button("☰"))
+					if (GUILayout.Button("☰", UIUserOverrides.getButtonStyleOverride()))
 					{
 						s.Collapsed = !s.Collapsed;
 					}
 					GUILayout.EndHorizontal();
 
 					var status = s.Enabled == 0 ? "ignore" : s.Enabled == 1 ? "zero" : "on";
-					if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage[status], GUILayout.Width(60)))
+					if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage[status], UIUserOverrides.getButtonStyleOverride()))
 					{
 						s.Enabled -= 1;
 					}
 
 					GUILayout.BeginHorizontal();
 					GUILayout.FlexibleSpace();
-					GUILayout.Label(ShapeKeyMaster.CurrentLanguage["shapekey"], GUILayout.Width(200));
+					GUILayout.Label(ShapeKeyMaster.CurrentLanguage["shapekey"], UIUserOverrides.getLabelStyleOverride(), GUILayout.Width(ShapeKeyMaster.MinShapekeyNameTextboxWidth.Value));
 					GUILayout.FlexibleSpace();
-					GUILayout.Label(ShapeKeyMaster.CurrentLanguage["maidOptional"], GUILayout.Width(200));
+					GUILayout.Label(ShapeKeyMaster.CurrentLanguage["maidOptional"], UIUserOverrides.getLabelStyleOverride(), GUILayout.Width(200));
 					GUILayout.FlexibleSpace();
 					GUILayout.EndHorizontal();
 
 					GUILayout.BeginHorizontal();
 					GUILayout.FlexibleSpace();
 
-					if (GUILayout.Button("+"))
+					if (GUILayout.Button("+", UIUserOverrides.getButtonStyleOverride()))
 					{
 						_openSkMenu = s.Id;
 						if (string.IsNullOrEmpty(s.Maid))
@@ -915,17 +978,17 @@ namespace ShapeKeyMaster.GUI
 						return;
 					}
 
-					s.ShapeKey = GUILayout.TextField(s.ShapeKey, GUILayout.Width(200));
+					s.ShapeKey = GUILayout.TextField(s.ShapeKey, UIUserOverrides.getTextFieldStyleOverride(), GUILayout.Width(ShapeKeyMaster.MinShapekeyNameTextboxWidth.Value));
 
 					GUILayout.FlexibleSpace();
 
-					if (GUILayout.Button("+"))
+					if (GUILayout.Button("+", UIUserOverrides.getButtonStyleOverride()))
 					{
 						_openMaidMenu = s.Id;
 						_maidNameList = Extensions.GetNameOfAllMaids().ToList();
 						return;
 					}
-					GUILayout.Label(s.Maid, GUILayout.Width(200));
+					GUILayout.Label(s.Maid, UIUserOverrides.getLabelStyleOverride(), GUILayout.Width(200));
 
 					GUILayout.FlexibleSpace();
 
@@ -933,70 +996,70 @@ namespace ShapeKeyMaster.GUI
 
 					//s.SetAnimateWithOrgasm(GUILayout.Toggle(s.GetAnimateWithOrgasm(), $"Animate during orgasm"));
 
-					s.Animate = GUILayout.Toggle(s.Animate, ShapeKeyMaster.CurrentLanguage["animate"]);
+					s.Animate = GUILayout.Toggle(s.Animate, ShapeKeyMaster.CurrentLanguage["animate"], UIUserOverrides.getToggleStyleOverride());
 
-					s.AnimateWithExcitement = GUILayout.Toggle(s.AnimateWithExcitement, ShapeKeyMaster.CurrentLanguage["animateWithYotogiExcitement"]);
+					s.AnimateWithExcitement = GUILayout.Toggle(s.AnimateWithExcitement, ShapeKeyMaster.CurrentLanguage["animateWithYotogiExcitement"], UIUserOverrides.getToggleStyleOverride());
 
 					switch (s.Animate)
 					{
 						case true:
 							GUILayout.Label(
-								$"{ShapeKeyMaster.CurrentLanguage["animationSpeed"]} = (1000 ms / {s.AnimationPollFloat * 1000} ms) x {s.AnimationRate} = {1000 / (s.AnimationPollFloat * 1000) * s.AnimationRateFloat} %/{ShapeKeyMaster.CurrentLanguage["seconds"]}");
+								$"{ShapeKeyMaster.CurrentLanguage["animationSpeed"]} = (1000 ms / {s.AnimationPollFloat * 1000} ms) x {s.AnimationRate} = {1000 / (s.AnimationPollFloat * 1000) * s.AnimationRateFloat} %/{ShapeKeyMaster.CurrentLanguage["seconds"]}", UIUserOverrides.getLabelStyleOverride());
 
-							GUILayout.Label(ShapeKeyMaster.CurrentLanguage["shapekeyDeformation"]);
+							GUILayout.Label(ShapeKeyMaster.CurrentLanguage["shapekeyDeformation"], UIUserOverrides.getLabelStyleOverride());
 							s.Deform = Mathf.RoundToInt(HorizontalSliderWithInputBox(s.Deform, 0, ShapeKeyMaster.MaxDeform.Value));
-							GUILayout.Label(ShapeKeyMaster.CurrentLanguage["maxAnimationDeformation"]);
+							GUILayout.Label(ShapeKeyMaster.CurrentLanguage["maxAnimationDeformation"], UIUserOverrides.getLabelStyleOverride());
 							s.AnimationMaximum = Mathf.RoundToInt(HorizontalSliderWithInputBox(s.AnimationMaximum, s.AnimationMinimum, ShapeKeyMaster.MaxDeform.Value));
-							GUILayout.Label(ShapeKeyMaster.CurrentLanguage["minAnimationDeformation"]);
+							GUILayout.Label(ShapeKeyMaster.CurrentLanguage["minAnimationDeformation"], UIUserOverrides.getLabelStyleOverride());
 							s.AnimationMinimum = Mathf.RoundToInt(HorizontalSliderWithInputBox(s.AnimationMinimum, 0, ShapeKeyMaster.MaxDeform.Value));
 
-							GUILayout.Label($"{ShapeKeyMaster.CurrentLanguage["animationRate"]}: {s.AnimationRate}");
+							GUILayout.Label($"{ShapeKeyMaster.CurrentLanguage["animationRate"]}: {s.AnimationRate}", UIUserOverrides.getLabelStyleOverride());
 							GUILayout.BeginHorizontal();
-							s.AnimationRate = GUILayout.TextField(s.AnimationRate);
+							s.AnimationRate = GUILayout.TextField(s.AnimationRate, UIUserOverrides.getTextFieldStyleOverride());
 							GUILayout.EndHorizontal();
-							GUILayout.Label($"{ShapeKeyMaster.CurrentLanguage["animationPollingRate"]}: {s.AnimationPoll}");
-							s.AnimationPoll = GUILayout.TextField(s.AnimationPoll);
+							GUILayout.Label($"{ShapeKeyMaster.CurrentLanguage["animationPollingRate"]}: {s.AnimationPoll}", UIUserOverrides.getLabelStyleOverride());
+							s.AnimationPoll = GUILayout.TextField(s.AnimationPoll, UIUserOverrides.getTextFieldStyleOverride());
 							break;
 
 						case false when s.AnimateWithExcitement:
 
-							GUILayout.Label(ShapeKeyMaster.CurrentLanguage["maxExcitementThreshold"]);
+							GUILayout.Label(ShapeKeyMaster.CurrentLanguage["maxExcitementThreshold"], UIUserOverrides.getLabelStyleOverride());
 							s.ExcitementMax = Mathf.RoundToInt(HorizontalSliderWithInputBox(s.ExcitementMax, 0, ShapeKeyMaster.MaxDeform.Value));
-							GUILayout.Label(ShapeKeyMaster.CurrentLanguage["minExcitementThreshold"]);
+							GUILayout.Label(ShapeKeyMaster.CurrentLanguage["minExcitementThreshold"], UIUserOverrides.getLabelStyleOverride());
 							s.ExcitementMin = Mathf.RoundToInt(HorizontalSliderWithInputBox(s.ExcitementMin, 0, ShapeKeyMaster.MaxDeform.Value));
-							GUILayout.Label(ShapeKeyMaster.CurrentLanguage["defShapekeyDeformation"]);
+							GUILayout.Label(ShapeKeyMaster.CurrentLanguage["defShapekeyDeformation"], UIUserOverrides.getLabelStyleOverride());
 							s.Deform = Mathf.RoundToInt(HorizontalSliderWithInputBox(s.Deform, 0, ShapeKeyMaster.MaxDeform.Value));
-							GUILayout.Label(ShapeKeyMaster.CurrentLanguage["maxShapekeyDeformation"]);
+							GUILayout.Label(ShapeKeyMaster.CurrentLanguage["maxShapekeyDeformation"], UIUserOverrides.getLabelStyleOverride());
 							s.DeformMax = Mathf.RoundToInt(HorizontalSliderWithInputBox(s.DeformMax, s.DeformMin, ShapeKeyMaster.MaxDeform.Value));
-							GUILayout.Label(ShapeKeyMaster.CurrentLanguage["minShapekeyDeformation"]);
+							GUILayout.Label(ShapeKeyMaster.CurrentLanguage["minShapekeyDeformation"], UIUserOverrides.getLabelStyleOverride());
 							s.DeformMin = Mathf.RoundToInt(HorizontalSliderWithInputBox(s.DeformMin, 0, s.DeformMax));
 							break;
 
 						default:
-							GUILayout.Label(ShapeKeyMaster.CurrentLanguage["shapekeyDeformation"]);
+							GUILayout.Label(ShapeKeyMaster.CurrentLanguage["shapekeyDeformation"], UIUserOverrides.getLabelStyleOverride());
 							s.Deform = Mathf.RoundToInt(HorizontalSliderWithInputBox(s.Deform, 0, ShapeKeyMaster.MaxDeform.Value));
 							break;
 					}
 
 					GUILayout.BeginHorizontal(style);
 
-					if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["openSlotCondMenu"]))
+					if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["openSlotCondMenu"], UIUserOverrides.getButtonStyleOverride()))
 					{
 						_openSlotConditions = s.Id;
 						return;
 					}
 
-					s.ConditionalsToggle = GUILayout.Toggle(s.ConditionalsToggle, ShapeKeyMaster.CurrentLanguage["enableConditionals"]);
+					s.ConditionalsToggle = GUILayout.Toggle(s.ConditionalsToggle, ShapeKeyMaster.CurrentLanguage["enableConditionals"], UIUserOverrides.getToggleStyleOverride());
 
 					GUILayout.FlexibleSpace();
 
-					if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["rename"]))
+					if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["rename"], UIUserOverrides.getButtonStyleOverride()))
 					{
 						_openRenameMenu = s.Id;
 						return;
 					}
 
-					if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["delete"]))
+					if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["delete"], UIUserOverrides.getButtonStyleOverride()))
 					{
 						SkDatabase.Remove(s);
 						return;
@@ -1007,9 +1070,9 @@ namespace ShapeKeyMaster.GUI
 				else
 				{
 					GUILayout.BeginHorizontal(_sections);
-					GUILayout.Label(s.EntryName);
+					GUILayout.Label(s.EntryName, UIUserOverrides.getLabelStyleOverride());
 					GUILayout.FlexibleSpace();
-					if (GUILayout.Button("☰"))
+					if (GUILayout.Button("☰", UIUserOverrides.getButtonStyleOverride()))
 					{
 						s.Collapsed = !s.Collapsed;
 					}
@@ -1022,19 +1085,19 @@ namespace ShapeKeyMaster.GUI
 		//From here on down are submenus....
 		private static void DisplayShapeKeySelectMenu(ShapeKeyEntry s)
 		{
-			DisplaySearchMenu(true);
+            DisplaySearchMenu(true);
 
 			GUILayout.BeginHorizontal();
 
-			GUILayout.Label($"{s.EntryName}: {ShapeKeyMaster.CurrentLanguage["selectShapekey"]}");
+			GUILayout.Label($"{s.EntryName}: {ShapeKeyMaster.CurrentLanguage["selectShapekey"]}", UIUserOverrides.getLabelStyleOverride());
 
 			GUILayout.FlexibleSpace();
 
-			GUILayout.Label(ShapeKeyMaster.CurrentLanguage["rclickToBlacklist"]);
+			GUILayout.Label(ShapeKeyMaster.CurrentLanguage["rclickToBlacklist"], UIUserOverrides.getLabelStyleOverride());
 
 			GUILayout.EndHorizontal();
 
-			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["finish"]))
+			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["finish"], UIUserOverrides.getButtonStyleOverride()))
 			{
 				_openSkMenu = Guid.Empty;
 				_oldSkMenuFilter = _filter;
@@ -1044,7 +1107,7 @@ namespace ShapeKeyMaster.GUI
 				_filter = "";
 			}
 
-			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["none"]))
+			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["none"], UIUserOverrides.getButtonStyleOverride()))
 			{
 				_openSkMenu = Guid.Empty;
 				_oldSkMenuFilter = _filter;
@@ -1113,7 +1176,7 @@ namespace ShapeKeyMaster.GUI
 					//Header for category
 					GUILayout.BeginHorizontal(_sections2);
 					GUILayout.FlexibleSpace();
-					GUILayout.Label(ShapeKeyMaster.CurrentLanguage[group.Key]);
+					GUILayout.Label(ShapeKeyMaster.CurrentLanguage[group.Key], UIUserOverrides.getLabelStyleOverride());
 					GUILayout.FlexibleSpace();
 					GUILayout.EndHorizontal();
 
@@ -1127,7 +1190,7 @@ namespace ShapeKeyMaster.GUI
 							}
 						}
 
-						var style = _hideBlacklistedKeys == false && SkDatabase.BlacklistedShapeKeys.IsBlacklisted(str.item2) ? _blacklistedButton : UnityEngine.GUI.skin.button;
+						var style = _hideBlacklistedKeys == false && SkDatabase.BlacklistedShapeKeys.IsBlacklisted(str.item2) ? _blacklistedButton : UIUserOverrides.getButtonStyleOverride();
 						if (GUILayout.Button(str.item2, style))
 						{
 							switch (LastMouseButtonUp)
@@ -1165,13 +1228,13 @@ namespace ShapeKeyMaster.GUI
 
 		private static void DisplayMaidSelectMenu(ShapeKeyEntry s)
 		{
-			DisplaySearchMenu(true);
+            DisplaySearchMenu(true);
 
-			GUILayout.Label($"{s.EntryName} {ShapeKeyMaster.CurrentLanguage["selectMaid"]}");
+			GUILayout.Label($"{s.EntryName} {ShapeKeyMaster.CurrentLanguage["selectMaid"]}", UIUserOverrides.getLabelStyleOverride());
 
 			GUILayout.BeginHorizontal(_sections2);
 
-			s.Maid = GUILayout.TextField(s.Maid, GUILayout.Width(200));
+			s.Maid = GUILayout.TextField(s.Maid, UIUserOverrides.getTextFieldStyleOverride(), GUILayout.Width(200));
 
 			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["finish"], GUILayout.Width(80)))
 			{
@@ -1180,7 +1243,7 @@ namespace ShapeKeyMaster.GUI
 
 			GUILayout.EndHorizontal();
 
-			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["none"]))
+			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["none"], UIUserOverrides.getButtonStyleOverride()))
 			{
 				_openMaidMenu = Guid.Empty;
 				s.Maid = "";
@@ -1197,7 +1260,7 @@ namespace ShapeKeyMaster.GUI
 					}
 				}
 
-				if (GUILayout.Button(mn))
+				if (GUILayout.Button(mn, UIUserOverrides.getButtonStyleOverride()))
 				{
 					_openMaidMenu = Guid.Empty;
 					s.Maid = mn;
@@ -1208,11 +1271,11 @@ namespace ShapeKeyMaster.GUI
 
 		private static void DisplayMaidGroupCreateMenu(Dictionary<Guid, ShapeKeyEntry> givenShapeKeys)
 		{
-			DisplaySearchMenu(true);
+            DisplaySearchMenu(true);
 
-			GUILayout.Label(ShapeKeyMaster.CurrentLanguage["selectNewMaidGroup"]);
+			GUILayout.Label(ShapeKeyMaster.CurrentLanguage["selectNewMaidGroup"], UIUserOverrides.getLabelStyleOverride());
 
-			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["none"]))
+			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["none"], UIUserOverrides.getButtonStyleOverride()))
 			{
 				int i;
 
@@ -1241,7 +1304,7 @@ namespace ShapeKeyMaster.GUI
 					}
 				}
 
-				if (GUILayout.Button(mn))
+				if (GUILayout.Button(mn, UIUserOverrides.getButtonStyleOverride()))
 				{
 					var newKey = Guid.NewGuid();
 
@@ -1258,11 +1321,11 @@ namespace ShapeKeyMaster.GUI
 
 		private static void DisplayRenameMenu(ShapeKeyEntry s)
 		{
-			GUILayout.Label($"{ShapeKeyMaster.CurrentLanguage["nowRenaming"]} {s.EntryName}");
+            GUILayout.Label($"{ShapeKeyMaster.CurrentLanguage["nowRenaming"]} {s.EntryName}", UIUserOverrides.getLabelStyleOverride());
 
-			s.EntryName = GUILayout.TextField(s.EntryName);
+			s.EntryName = GUILayout.TextField(s.EntryName, UIUserOverrides.getTextFieldStyleOverride());
 
-			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["finish"]))
+			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["finish"], UIUserOverrides.getButtonStyleOverride()))
 			{
 				_openRenameMenu = Guid.Empty;
 			}
@@ -1270,24 +1333,24 @@ namespace ShapeKeyMaster.GUI
 
 		private static void DisplaySlotConditionsMenu(ShapeKeyEntry s)
 		{
-			GUILayout.BeginVertical(_sections);
+            GUILayout.BeginVertical(_sections);
 
 			GUILayout.BeginHorizontal(_sections2);
 			GUILayout.FlexibleSpace();
-			GUILayout.Label(ShapeKeyMaster.CurrentLanguage["generalSettings"]);
+			GUILayout.Label(ShapeKeyMaster.CurrentLanguage["generalSettings"], UIUserOverrides.getLabelStyleOverride());
 			GUILayout.FlexibleSpace();
 			GUILayout.EndHorizontal();
 
-			s.ConditionalsToggle = GUILayout.Toggle(s.ConditionalsToggle, ShapeKeyMaster.CurrentLanguage["enableConditionals"]);
+			s.ConditionalsToggle = GUILayout.Toggle(s.ConditionalsToggle, ShapeKeyMaster.CurrentLanguage["enableConditionals"], UIUserOverrides.getToggleStyleOverride());
 
-			s.IgnoreCategoriesWithShapekey = GUILayout.Toggle(s.IgnoreCategoriesWithShapekey, ShapeKeyMaster.CurrentLanguage["ignoreCateWithKey"]);
+			s.IgnoreCategoriesWithShapekey = GUILayout.Toggle(s.IgnoreCategoriesWithShapekey, ShapeKeyMaster.CurrentLanguage["ignoreCateWithKey"], UIUserOverrides.getToggleStyleOverride());
 
-			s.DisableWhen = GUILayout.Toggle(s.DisableWhen, s.DisableWhen ? ShapeKeyMaster.CurrentLanguage["setShapekeyIf"] : ShapeKeyMaster.CurrentLanguage["doNotSetShapekeyIf"]);
+			s.DisableWhen = GUILayout.Toggle(s.DisableWhen, s.DisableWhen ? ShapeKeyMaster.CurrentLanguage["setShapekeyIf"] : ShapeKeyMaster.CurrentLanguage["doNotSetShapekeyIf"], UIUserOverrides.getToggleStyleOverride());
 
-			GUILayout.Label(ShapeKeyMaster.CurrentLanguage["disabledKeyDeform"]);
+			GUILayout.Label(ShapeKeyMaster.CurrentLanguage["disabledKeyDeform"], UIUserOverrides.getLabelStyleOverride());
 			s.DisabledDeform = GUILayout.HorizontalSlider(s.DisabledDeform, 0, ShapeKeyMaster.MaxDeform.Value);
 
-			s.WhenAll = GUILayout.Toggle(s.WhenAll, s.WhenAll ? ShapeKeyMaster.CurrentLanguage["ifAllSlotsEquipped"] : ShapeKeyMaster.CurrentLanguage["ifAnySlotEquipped"]);
+			s.WhenAll = GUILayout.Toggle(s.WhenAll, s.WhenAll ? ShapeKeyMaster.CurrentLanguage["ifAllSlotsEquipped"] : ShapeKeyMaster.CurrentLanguage["ifAnySlotEquipped"], UIUserOverrides.getToggleStyleOverride());
 
 			GUILayout.EndHorizontal();
 
@@ -1295,7 +1358,7 @@ namespace ShapeKeyMaster.GUI
 
 			GUILayout.BeginHorizontal(_sections2);
 			GUILayout.FlexibleSpace();
-			GUILayout.Label(ShapeKeyMaster.CurrentLanguage["slots"]);
+			GUILayout.Label(ShapeKeyMaster.CurrentLanguage["slots"], UIUserOverrides.getLabelStyleOverride());
 			GUILayout.FlexibleSpace();
 			GUILayout.EndHorizontal();
 
@@ -1308,7 +1371,7 @@ namespace ShapeKeyMaster.GUI
 					GUILayout.BeginHorizontal();
 				}
 
-				var temp = GUILayout.Toggle(s.SlotFlags.HasFlag(slot), ShapeKeyMaster.CurrentLanguage[SlotChecker.SlotToSlotList[slot].ToString()], GUILayout.Width(100));
+				var temp = GUILayout.Toggle(s.SlotFlags.HasFlag(slot), ShapeKeyMaster.CurrentLanguage[SlotChecker.SlotToSlotList[slot].ToString()], UIUserOverrides.getToggleStyleOverride(), GUILayout.Width(100));
 
 				if (i++ == 4)
 				{
@@ -1337,7 +1400,7 @@ namespace ShapeKeyMaster.GUI
 
 			GUILayout.BeginHorizontal(_sections2);
 			GUILayout.FlexibleSpace();
-			GUILayout.Label(ShapeKeyMaster.CurrentLanguage["menuFiles"]);
+			GUILayout.Label(ShapeKeyMaster.CurrentLanguage["menuFiles"], UIUserOverrides.getLabelStyleOverride());
 			GUILayout.FlexibleSpace();
 			GUILayout.EndHorizontal();
 
@@ -1349,27 +1412,27 @@ namespace ShapeKeyMaster.GUI
 			{
 				GUILayout.BeginHorizontal();
 
-				if (GUILayout.Button("X", GUILayout.Width(20)))
+				if (GUILayout.Button("X", UIUserOverrides.getButtonStyleOverride(), GUILayout.Width(20)))
 				{
 					s.MenuFileConditionals.Remove(menu);
 					return;
 				}
 
-				s.MenuFileConditionals[menu] = GUILayout.TextField(s.MenuFileConditionals[menu]);
+				s.MenuFileConditionals[menu] = GUILayout.TextField(s.MenuFileConditionals[menu], UIUserOverrides.getTextFieldStyleOverride());
 
 				GUILayout.EndHorizontal();
 			}
 
 			GUILayout.EndScrollView();
 
-			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["addNewMenuFile"]))
+			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["addNewMenuFile"], UIUserOverrides.getButtonStyleOverride()))
 			{
 				s.MenuFileConditionals[Guid.NewGuid()] = "";
 			}
 
 			GUILayout.EndVertical();
 
-			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["finish"]))
+			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["finish"], UIUserOverrides.getButtonStyleOverride()))
 			{
 				_openSlotConditions = Guid.Empty;
 			}
@@ -1377,15 +1440,15 @@ namespace ShapeKeyMaster.GUI
 
 		private static void DisplayMaidRenameMenu(string s)
 		{
-			DisplaySearchMenu(true);
+            DisplaySearchMenu(true);
 
-			GUILayout.Label($"{ShapeKeyMaster.CurrentLanguage["renamingMaidGroup"]}: {s}");
+			GUILayout.Label($"{ShapeKeyMaster.CurrentLanguage["renamingMaidGroup"]}: {s}", UIUserOverrides.getLabelStyleOverride());
 
 			GUILayout.BeginHorizontal();
 
-			_maidGroupRename = GUILayout.TextField(_maidGroupRename);
+			_maidGroupRename = GUILayout.TextField(_maidGroupRename, UIUserOverrides.getTextFieldStyleOverride());
 
-			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["apply"]))
+			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["apply"], UIUserOverrides.getButtonStyleOverride()))
 			{
 				SkDatabase.AllShapekeyDictionary.Values.ToList().ForEach(sk =>
 				{
@@ -1412,7 +1475,7 @@ namespace ShapeKeyMaster.GUI
 					}
 				}
 
-				if (GUILayout.Button(mn))
+				if (GUILayout.Button(mn, UIUserOverrides.getButtonStyleOverride()))
 				{
 					SkDatabase.AllShapekeyDictionary.Values.ToList().ForEach(sk =>
 					{
@@ -1431,9 +1494,9 @@ namespace ShapeKeyMaster.GUI
 
 		private static void DisplayExportMenu()
 		{
-			ShapeKeyMaster.HideInactiveMaids.Value = GUILayout.Toggle(ShapeKeyMaster.HideInactiveMaids.Value, ShapeKeyMaster.CurrentLanguage["hideInactiveMaids"]);
+            ShapeKeyMaster.HideInactiveMaids.Value = GUILayout.Toggle(ShapeKeyMaster.HideInactiveMaids.Value, ShapeKeyMaster.CurrentLanguage["hideInactiveMaids"], UIUserOverrides.getToggleStyleOverride());
 
-			if (ShapeKeyMaster.HideInactiveMaids.Value == false && GUILayout.Button(ShapeKeyMaster.CurrentLanguage["all"]))
+			if (ShapeKeyMaster.HideInactiveMaids.Value == false && GUILayout.Button(ShapeKeyMaster.CurrentLanguage["all"], UIUserOverrides.getButtonStyleOverride()))
 			{
 				ShapeKeyMaster.pluginLogger.LogMessage(ShapeKeyMaster.CurrentLanguage["exportingAll"]);
 
@@ -1447,7 +1510,7 @@ namespace ShapeKeyMaster.GUI
 				ThingsToExport["global"] = false;
 			}
 
-			ThingsToExport["global"] = GUILayout.Toggle(ThingsToExport["global"], ShapeKeyMaster.CurrentLanguage["global"]);
+			ThingsToExport["global"] = GUILayout.Toggle(ThingsToExport["global"], ShapeKeyMaster.CurrentLanguage["global"], UIUserOverrides.getToggleStyleOverride());
 
 			foreach (var m in SkDatabase.ListOfMaidsWithKeys())
 			{
@@ -1458,12 +1521,12 @@ namespace ShapeKeyMaster.GUI
 					ThingsToExport[m] = false;
 				}
 
-				ThingsToExport[m] = GUILayout.Toggle(ThingsToExport[m], m);
+				ThingsToExport[m] = GUILayout.Toggle(ThingsToExport[m], m, UIUserOverrides.getToggleStyleOverride());
 			}
 
 			GUILayout.EndVertical();
 
-			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["done"]))
+			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["done"], UIUserOverrides.getButtonStyleOverride()))
 			{
 				var selectionDataBase = new ShapeKeyDatabase();
 

--- a/ShapekeyMaster/GUI/UI.cs
+++ b/ShapekeyMaster/GUI/UI.cs
@@ -183,7 +183,11 @@ namespace ShapeKeyMaster.GUI
 				_currentWidth = Screen.width;
 			}
 
+			UnityEngine.GUI.skin = UIUserOverrides.CustomSkin;
+
 			WindowRect = GUILayout.Window(WindowId, WindowRect, GuiWindowControls, ShapeKeyMaster.CurrentLanguage["title"], _mainWindow);
+
+			UnityEngine.GUI.skin = null;
 		}
 
 		private static void GuiWindowControls(int windowId)
@@ -241,10 +245,10 @@ namespace ShapeKeyMaster.GUI
 
 				GUILayout.BeginHorizontal();
 
-				ShapeKeyMaster.SimpleMode.Value = GUILayout.Toggle(ShapeKeyMaster.SimpleMode.Value, ShapeKeyMaster.CurrentLanguage["simple"], UIUserOverrides.getToggleStyleOverride());
+				ShapeKeyMaster.SimpleMode.Value = GUILayout.Toggle(ShapeKeyMaster.SimpleMode.Value, ShapeKeyMaster.CurrentLanguage["simple"]);
 				if (ShapeKeyMaster.SimpleMode.Value)
 				{
-					ShapeKeyMaster.SimpleMode_ShowMoreFunctions.Value = GUILayout.Toggle(ShapeKeyMaster.SimpleMode_ShowMoreFunctions.Value, ShapeKeyMaster.CurrentLanguage["showMoreFunctions"], UIUserOverrides.getToggleStyleOverride());
+					ShapeKeyMaster.SimpleMode_ShowMoreFunctions.Value = GUILayout.Toggle(ShapeKeyMaster.SimpleMode_ShowMoreFunctions.Value, ShapeKeyMaster.CurrentLanguage["showMoreFunctions"]);
 				}
 
 				GUILayout.EndHorizontal();
@@ -279,13 +283,13 @@ namespace ShapeKeyMaster.GUI
 						break;
 
 					case 2:
-						ShapeKeyMaster.HideInactiveMaids.Value = GUILayout.Toggle(ShapeKeyMaster.HideInactiveMaids.Value, ShapeKeyMaster.CurrentLanguage["hideInactiveMaids"], UIUserOverrides.getToggleStyleOverride());
+						ShapeKeyMaster.HideInactiveMaids.Value = GUILayout.Toggle(ShapeKeyMaster.HideInactiveMaids.Value, ShapeKeyMaster.CurrentLanguage["hideInactiveMaids"]);
 
 						GUILayout.BeginVertical(_sections);
 
 						GUILayout.BeginHorizontal(_sections2);
 						GUILayout.FlexibleSpace();
-						GUILayout.Label(ShapeKeyMaster.CurrentLanguage["maids"], UIUserOverrides.getLabelStyleOverride());
+						GUILayout.Label(ShapeKeyMaster.CurrentLanguage["maids"]);
 						GUILayout.FlexibleSpace();
 						GUILayout.EndHorizontal();
 
@@ -337,29 +341,29 @@ namespace ShapeKeyMaster.GUI
 			var modeLabel = EntryComparer.Mode == 0 ? ShapeKeyMaster.CurrentLanguage["date"] : EntryComparer.Mode == 1 ? ShapeKeyMaster.CurrentLanguage["name"] : EntryComparer.Mode == 2 ? ShapeKeyMaster.CurrentLanguage["shapekey"] : "GUID";
 			var ascendLabel = EntryComparer.Ascending ? "↑" : "↓";
 
-			GUILayout.Label(ShapeKeyMaster.CurrentLanguage["sortBy"] + ":", UIUserOverrides.getLabelStyleOverride());
-			if (GUILayout.Button(modeLabel, UIUserOverrides.getButtonStyleOverride()))
+			GUILayout.Label(ShapeKeyMaster.CurrentLanguage["sortBy"] + ":");
+			if (GUILayout.Button(modeLabel))
 			{
 				++EntryComparer.Mode;
 			}
-			if (GUILayout.Button(ascendLabel, UIUserOverrides.getButtonStyleOverride()))
+			if (GUILayout.Button(ascendLabel))
 			{
 				EntryComparer.Ascending = !EntryComparer.Ascending;
 			}
 
 			GUILayout.FlexibleSpace();
 
-			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["all"], UIUserOverrides.getButtonStyleOverride()))
+			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["all"]))
 			{
 				_page = 0;
 				_tabSelection = 0;
 			}
-			else if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["globals"], UIUserOverrides.getButtonStyleOverride()))
+			else if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["globals"]))
 			{
 				_page = 0;
 				_tabSelection = 1;
 			}
-			else if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["maids"], UIUserOverrides.getButtonStyleOverride()))
+			else if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["maids"]))
 			{
 				_page = 0;
 				_tabSelection = 2;
@@ -376,41 +380,41 @@ namespace ShapeKeyMaster.GUI
 
 			if (_openSkMenu != Guid.Empty)
 			{
-				_filterCommonKeys = GUILayout.Toggle(_filterCommonKeys, ShapeKeyMaster.CurrentLanguage["filterCommonKeys"], UIUserOverrides.getToggleStyleOverride());
+				_filterCommonKeys = GUILayout.Toggle(_filterCommonKeys, ShapeKeyMaster.CurrentLanguage["filterCommonKeys"]);
 
-				_hideBlacklistedKeys = GUILayout.Toggle(_hideBlacklistedKeys, ShapeKeyMaster.CurrentLanguage["hideBlacklistedKeys"], UIUserOverrides.getToggleStyleOverride());
+				_hideBlacklistedKeys = GUILayout.Toggle(_hideBlacklistedKeys, ShapeKeyMaster.CurrentLanguage["hideBlacklistedKeys"]);
 			}
 
 			GUILayout.FlexibleSpace();
 
-			GUILayout.Label(ShapeKeyMaster.CurrentLanguage["searchBy"] + ":", UIUserOverrides.getLabelStyleOverride());
+			GUILayout.Label(ShapeKeyMaster.CurrentLanguage["searchBy"] + ":");
 
 			if (noModes == false)
 			{
 				if (_filterMode == 0)
 				{
-					if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["name"], UIUserOverrides.getButtonStyleOverride()))
+					if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["name"]))
 					{
 						_filterMode = 1;
 					}
 				}
 				else if (_filterMode == 1)
 				{
-					if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["maid"], UIUserOverrides.getButtonStyleOverride()))
+					if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["maid"]))
 					{
 						_filterMode = 2;
 					}
 				}
 				else if (_filterMode == 2)
 				{
-					if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["shapekey"], UIUserOverrides.getButtonStyleOverride()))
+					if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["shapekey"]))
 					{
 						_filterMode = 0;
 					}
 				}
 			}
 
-			_filter = GUILayout.TextField(_filter, UIUserOverrides.getTextFieldStyleOverride(), GUILayout.Width(160));
+			_filter = GUILayout.TextField(_filter, GUILayout.Width(160));
 
 			GUILayout.EndHorizontal();
 		}
@@ -439,14 +443,14 @@ namespace ShapeKeyMaster.GUI
 			}
 
 			GUILayout.BeginHorizontal(_sections2);
-			if (GUILayout.Button("<<", UIUserOverrides.getButtonStyleOverride()))
+			if (GUILayout.Button("<<"))
 			{
 				_page = Math.Max(_page - ShapeKeyMaster.EntriesPerPage.Value, 0);
 			}
 			GUILayout.FlexibleSpace();
-			GUILayout.Label($"{headerString}:{_page} ~ {_page + ShapeKeyMaster.EntriesPerPage.Value}", UIUserOverrides.getLabelStyleOverride());
+			GUILayout.Label($"{headerString}:{_page} ~ {_page + ShapeKeyMaster.EntriesPerPage.Value}");
 			GUILayout.FlexibleSpace();
-			if (GUILayout.Button(">>", UIUserOverrides.getButtonStyleOverride()))
+			if (GUILayout.Button(">>"))
 			{
 				if (_page + ShapeKeyMaster.EntriesPerPage.Value < applicantCount)
 				{
@@ -461,7 +465,7 @@ namespace ShapeKeyMaster.GUI
 			GUILayout.BeginVertical(_sections2);
 			if (_exportMenuOpen)
 			{
-				if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["cancel"], UIUserOverrides.getButtonStyleOverride()))
+				if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["cancel"]))
 				{
 					_exportMenuOpen = false;
 				}
@@ -469,7 +473,7 @@ namespace ShapeKeyMaster.GUI
 			else
 			{
 				GUILayout.BeginHorizontal();
-				if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["reload"], UIUserOverrides.getButtonStyleOverride()))
+				if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["reload"]))
 				{
 					_openSkMenu = Guid.Empty;
 					_openMaidMenu = Guid.Empty;
@@ -483,7 +487,7 @@ namespace ShapeKeyMaster.GUI
 
 					return;
 				}
-				if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["save"], UIUserOverrides.getButtonStyleOverride()))
+				if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["save"]))
 				{
 #if (DEBUG)
 					ShapeKeyMaster.pluginLogger.LogDebug("Saving data to configs now!");
@@ -493,11 +497,11 @@ namespace ShapeKeyMaster.GUI
 				}
 				GUILayout.EndHorizontal();
 				GUILayout.BeginHorizontal();
-				if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["export"], UIUserOverrides.getButtonStyleOverride()))
+				if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["export"]))
 				{
 					_exportMenuOpen = true;
 				}
-				if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["import"], UIUserOverrides.getButtonStyleOverride()))
+				if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["import"]))
 				{
 					SkDatabase.ConcatenateDictionary(ShapeKeyMaster.LoadFromJson(null, true).AllShapekeyDictionary);
 
@@ -535,9 +539,9 @@ namespace ShapeKeyMaster.GUI
 
 				GUILayout.BeginVertical(_sections);
 				GUILayout.BeginHorizontal(_sections);
-				GUILayout.Label(maidWithKey, UIUserOverrides.getLabelStyleOverride());
+				GUILayout.Label(maidWithKey);
 
-				if (GUILayout.Button("I/O", UIUserOverrides.getButtonStyleOverride()))
+				if (GUILayout.Button("I/O"))
 				{
 					ShapeKeyEntry first = null;
 					foreach (var value in SkDatabase.ShapeKeysByMaid(maidWithKey).Values)
@@ -556,7 +560,7 @@ namespace ShapeKeyMaster.GUI
 					return;
 				}
 
-				if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["copy_to"], UIUserOverrides.getButtonStyleOverride()))
+				if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["copy_to"]))
 				{
 					var keysToCopy = SkDatabase.ShapeKeysByMaid(maidWithKey).Values;
 					var newKeys = keysToCopy.Select(r => r.Clone() as ShapeKeyEntry).ToDictionary(r => r.Id, m => m);
@@ -587,7 +591,7 @@ namespace ShapeKeyMaster.GUI
 					return;
 				}
 
-				if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["rename"], UIUserOverrides.getButtonStyleOverride()))
+				if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["rename"]))
 				{
 					_maidGroupRenameMenu = maidWithKey;
 					_maidGroupRename = _maidGroupRenameMenu;
@@ -597,7 +601,7 @@ namespace ShapeKeyMaster.GUI
 					return;
 				}
 
-				if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["delete"], UIUserOverrides.getButtonStyleOverride()))
+				if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["delete"]))
 				{
 					foreach (var skp in SkDatabase.ShapeKeysByMaid(maidWithKey).Values)
 					{
@@ -609,7 +613,7 @@ namespace ShapeKeyMaster.GUI
 
 				GUILayout.FlexibleSpace();
 
-				if (GUILayout.Button("☰", UIUserOverrides.getButtonStyleOverride()))
+				if (GUILayout.Button("☰"))
 				{
 					if (!_maidSelection.Contains(maidWithKey))
 					{
@@ -642,7 +646,7 @@ namespace ShapeKeyMaster.GUI
 
 					GUILayout.BeginHorizontal();
 
-					if (GUILayout.Button("+", UIUserOverrides.getButtonStyleOverride(), GUILayout.Width(40)))
+					if (GUILayout.Button("+", GUILayout.Width(40)))
 					{
 						var id = Guid.NewGuid();
 						SkDatabase.Add(new ShapeKeyEntry(id, maidWithKey));
@@ -662,7 +666,7 @@ namespace ShapeKeyMaster.GUI
 				GUILayout.EndVertical();
 			}
 
-			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["newMaidGroup"], UIUserOverrides.getButtonStyleOverride()))
+			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["newMaidGroup"]))
 			{
 				_maidNameList = Extensions.GetNameOfAllMaids().ToList();
 
@@ -691,12 +695,12 @@ namespace ShapeKeyMaster.GUI
 
 				GUILayout.BeginHorizontal();
 				var status = s.Enabled == 0 ? "ignore" : (s.Enabled == 1 ? "zero" : "on");
-				if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage[status], UIUserOverrides.getButtonStyleOverride()))
+				if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage[status]))
 				{
 					s.Enabled -= 1;
 				}
 
-				if (GUILayout.Button("+", UIUserOverrides.getButtonStyleOverride(), GUILayout.Width(30)))
+				if (GUILayout.Button("+", GUILayout.Width(30)))
 				{
 					if (string.IsNullOrEmpty(s.Maid))
 					{
@@ -717,11 +721,11 @@ namespace ShapeKeyMaster.GUI
 					_oldPreSkMenuScrollPosition = _scrollPosition;
 					_scrollPosition = _oldSkMenuScrollPosition;
 				}
-				s.ShapeKey = GUILayout.TextField(s.ShapeKey, UIUserOverrides.getTextFieldStyleOverride(), GUILayout.Width(ShapeKeyMaster.MinShapekeyNameTextboxWidth.Value));
+				s.ShapeKey = GUILayout.TextField(s.ShapeKey, GUILayout.Width(ShapeKeyMaster.MinShapekeyNameTextboxWidth.Value));
 				s.Deform = Mathf.RoundToInt(HorizontalSliderWithInputBox(s.Deform, 0, ShapeKeyMaster.MaxDeform.Value));
 				if (!ShapeKeyMaster.SimpleMode_ShowMoreFunctions.Value)
 				{
-					if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["delete"], UIUserOverrides.getButtonStyleOverride()))
+					if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["delete"]))
 					{
 						SkDatabase.Remove(s);
 					}
@@ -731,25 +735,25 @@ namespace ShapeKeyMaster.GUI
 				if (ShapeKeyMaster.SimpleMode_ShowMoreFunctions.Value)
 				{
 					GUILayout.BeginHorizontal(style);
-					if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["openSlotCondMenu"], UIUserOverrides.getButtonStyleOverride()))
+					if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["openSlotCondMenu"]))
 					{
 						_openSlotConditions = s.Id;
 					}
-					s.ConditionalsToggle = GUILayout.Toggle(s.ConditionalsToggle, ShapeKeyMaster.CurrentLanguage["enableConditionals"], UIUserOverrides.getToggleStyleOverride());
+					s.ConditionalsToggle = GUILayout.Toggle(s.ConditionalsToggle, ShapeKeyMaster.CurrentLanguage["enableConditionals"]);
 					var cateNameLabel = !string.IsNullOrEmpty(s.EntryName) ? s.EntryName : "";
 					cateNameLabel += _tabSelection == 0 && !string.IsNullOrEmpty(cateNameLabel) ? " | " : "";
 					cateNameLabel += _tabSelection == 0 ? string.IsNullOrEmpty(s.Maid) ? ShapeKeyMaster.CurrentLanguage["global"] : s.Maid : "";
 					cateNameLabel = cateNameLabel.Length > 25 ? cateNameLabel.Substring(0, 25) + "..." : cateNameLabel;
-					GUILayout.Label(cateNameLabel, UIUserOverrides.getLabelStyleOverride());
+					GUILayout.Label(cateNameLabel);
 					GUILayout.FlexibleSpace();
-					if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["copy"], UIUserOverrides.getButtonStyleOverride()))
+					if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["copy"]))
 					{
 						var newEntry = s.Clone() as ShapeKeyEntry;
 						newEntry.EntryName += "(Copy)";
 						SkDatabase.Add(newEntry);
 						FocusToNewKey(newEntry.Id, givenShapeKeys);
 					}
-					if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["delete"], UIUserOverrides.getButtonStyleOverride()))
+					if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["delete"]))
 					{
 						SkDatabase.Remove(s);
 					}
@@ -759,7 +763,7 @@ namespace ShapeKeyMaster.GUI
 				GUILayout.EndVertical();
 			}
 
-			if (_tabSelection != 2 && GUILayout.Button("+", UIUserOverrides.getButtonStyleOverride(), GUILayout.Width(40)))
+			if (_tabSelection != 2 && GUILayout.Button("+", GUILayout.Width(40)))
 			{
 #if (DEBUG)
 				ShapeKeyMaster.pluginLogger.LogDebug("I've been clicked! Oh the humanity!!");
@@ -899,7 +903,7 @@ namespace ShapeKeyMaster.GUI
 
 		private static void DisplayShapeKeyEntriesMenu(Dictionary<Guid, ShapeKeyEntry> givenShapeKeys)
 		{
-			if (_tabSelection != 2 && GUILayout.Button(ShapeKeyMaster.CurrentLanguage["addNewShapekey"], UIUserOverrides.getButtonStyleOverride()))
+			if (_tabSelection != 2 && GUILayout.Button(ShapeKeyMaster.CurrentLanguage["addNewShapekey"]))
 			{
 #if (DEBUG)
 				ShapeKeyMaster.pluginLogger.LogDebug("I've been clicked! Oh the humanity!!");
@@ -929,32 +933,32 @@ namespace ShapeKeyMaster.GUI
 				if (s.Collapsed == false)
 				{
 					GUILayout.BeginHorizontal(style);
-					GUILayout.Label(s.EntryName, UIUserOverrides.getLabelStyleOverride());
+					GUILayout.Label(s.EntryName);
 					GUILayout.FlexibleSpace();
-					if (GUILayout.Button("☰", UIUserOverrides.getButtonStyleOverride()))
+					if (GUILayout.Button("☰"))
 					{
 						s.Collapsed = !s.Collapsed;
 					}
 					GUILayout.EndHorizontal();
 
 					var status = s.Enabled == 0 ? "ignore" : s.Enabled == 1 ? "zero" : "on";
-					if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage[status], UIUserOverrides.getButtonStyleOverride()))
+					if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage[status]))
 					{
 						s.Enabled -= 1;
 					}
 
 					GUILayout.BeginHorizontal();
 					GUILayout.FlexibleSpace();
-					GUILayout.Label(ShapeKeyMaster.CurrentLanguage["shapekey"], UIUserOverrides.getLabelStyleOverride(), GUILayout.Width(ShapeKeyMaster.MinShapekeyNameTextboxWidth.Value));
+					GUILayout.Label(ShapeKeyMaster.CurrentLanguage["shapekey"], GUILayout.Width(ShapeKeyMaster.MinShapekeyNameTextboxWidth.Value));
 					GUILayout.FlexibleSpace();
-					GUILayout.Label(ShapeKeyMaster.CurrentLanguage["maidOptional"], UIUserOverrides.getLabelStyleOverride(), GUILayout.Width(200));
+					GUILayout.Label(ShapeKeyMaster.CurrentLanguage["maidOptional"], GUILayout.Width(200));
 					GUILayout.FlexibleSpace();
 					GUILayout.EndHorizontal();
 
 					GUILayout.BeginHorizontal();
 					GUILayout.FlexibleSpace();
 
-					if (GUILayout.Button("+", UIUserOverrides.getButtonStyleOverride()))
+					if (GUILayout.Button("+"))
 					{
 						_openSkMenu = s.Id;
 						if (string.IsNullOrEmpty(s.Maid))
@@ -978,17 +982,17 @@ namespace ShapeKeyMaster.GUI
 						return;
 					}
 
-					s.ShapeKey = GUILayout.TextField(s.ShapeKey, UIUserOverrides.getTextFieldStyleOverride(), GUILayout.Width(ShapeKeyMaster.MinShapekeyNameTextboxWidth.Value));
+					s.ShapeKey = GUILayout.TextField(s.ShapeKey, GUILayout.Width(ShapeKeyMaster.MinShapekeyNameTextboxWidth.Value));
 
 					GUILayout.FlexibleSpace();
 
-					if (GUILayout.Button("+", UIUserOverrides.getButtonStyleOverride()))
+					if (GUILayout.Button("+"))
 					{
 						_openMaidMenu = s.Id;
 						_maidNameList = Extensions.GetNameOfAllMaids().ToList();
 						return;
 					}
-					GUILayout.Label(s.Maid, UIUserOverrides.getLabelStyleOverride(), GUILayout.Width(200));
+					GUILayout.Label(s.Maid, GUILayout.Width(200));
 
 					GUILayout.FlexibleSpace();
 
@@ -996,70 +1000,70 @@ namespace ShapeKeyMaster.GUI
 
 					//s.SetAnimateWithOrgasm(GUILayout.Toggle(s.GetAnimateWithOrgasm(), $"Animate during orgasm"));
 
-					s.Animate = GUILayout.Toggle(s.Animate, ShapeKeyMaster.CurrentLanguage["animate"], UIUserOverrides.getToggleStyleOverride());
+					s.Animate = GUILayout.Toggle(s.Animate, ShapeKeyMaster.CurrentLanguage["animate"]);
 
-					s.AnimateWithExcitement = GUILayout.Toggle(s.AnimateWithExcitement, ShapeKeyMaster.CurrentLanguage["animateWithYotogiExcitement"], UIUserOverrides.getToggleStyleOverride());
+					s.AnimateWithExcitement = GUILayout.Toggle(s.AnimateWithExcitement, ShapeKeyMaster.CurrentLanguage["animateWithYotogiExcitement"]);
 
 					switch (s.Animate)
 					{
 						case true:
 							GUILayout.Label(
-								$"{ShapeKeyMaster.CurrentLanguage["animationSpeed"]} = (1000 ms / {s.AnimationPollFloat * 1000} ms) x {s.AnimationRate} = {1000 / (s.AnimationPollFloat * 1000) * s.AnimationRateFloat} %/{ShapeKeyMaster.CurrentLanguage["seconds"]}", UIUserOverrides.getLabelStyleOverride());
+								$"{ShapeKeyMaster.CurrentLanguage["animationSpeed"]} = (1000 ms / {s.AnimationPollFloat * 1000} ms) x {s.AnimationRate} = {1000 / (s.AnimationPollFloat * 1000) * s.AnimationRateFloat} %/{ShapeKeyMaster.CurrentLanguage["seconds"]}");
 
-							GUILayout.Label(ShapeKeyMaster.CurrentLanguage["shapekeyDeformation"], UIUserOverrides.getLabelStyleOverride());
+							GUILayout.Label(ShapeKeyMaster.CurrentLanguage["shapekeyDeformation"]);
 							s.Deform = Mathf.RoundToInt(HorizontalSliderWithInputBox(s.Deform, 0, ShapeKeyMaster.MaxDeform.Value));
-							GUILayout.Label(ShapeKeyMaster.CurrentLanguage["maxAnimationDeformation"], UIUserOverrides.getLabelStyleOverride());
+							GUILayout.Label(ShapeKeyMaster.CurrentLanguage["maxAnimationDeformation"]);
 							s.AnimationMaximum = Mathf.RoundToInt(HorizontalSliderWithInputBox(s.AnimationMaximum, s.AnimationMinimum, ShapeKeyMaster.MaxDeform.Value));
-							GUILayout.Label(ShapeKeyMaster.CurrentLanguage["minAnimationDeformation"], UIUserOverrides.getLabelStyleOverride());
+							GUILayout.Label(ShapeKeyMaster.CurrentLanguage["minAnimationDeformation"]);
 							s.AnimationMinimum = Mathf.RoundToInt(HorizontalSliderWithInputBox(s.AnimationMinimum, 0, ShapeKeyMaster.MaxDeform.Value));
 
-							GUILayout.Label($"{ShapeKeyMaster.CurrentLanguage["animationRate"]}: {s.AnimationRate}", UIUserOverrides.getLabelStyleOverride());
+							GUILayout.Label($"{ShapeKeyMaster.CurrentLanguage["animationRate"]}: {s.AnimationRate}");
 							GUILayout.BeginHorizontal();
-							s.AnimationRate = GUILayout.TextField(s.AnimationRate, UIUserOverrides.getTextFieldStyleOverride());
+							s.AnimationRate = GUILayout.TextField(s.AnimationRate);
 							GUILayout.EndHorizontal();
-							GUILayout.Label($"{ShapeKeyMaster.CurrentLanguage["animationPollingRate"]}: {s.AnimationPoll}", UIUserOverrides.getLabelStyleOverride());
-							s.AnimationPoll = GUILayout.TextField(s.AnimationPoll, UIUserOverrides.getTextFieldStyleOverride());
+							GUILayout.Label($"{ShapeKeyMaster.CurrentLanguage["animationPollingRate"]}: {s.AnimationPoll}");
+							s.AnimationPoll = GUILayout.TextField(s.AnimationPoll);
 							break;
 
 						case false when s.AnimateWithExcitement:
 
-							GUILayout.Label(ShapeKeyMaster.CurrentLanguage["maxExcitementThreshold"], UIUserOverrides.getLabelStyleOverride());
+							GUILayout.Label(ShapeKeyMaster.CurrentLanguage["maxExcitementThreshold"]);
 							s.ExcitementMax = Mathf.RoundToInt(HorizontalSliderWithInputBox(s.ExcitementMax, 0, ShapeKeyMaster.MaxDeform.Value));
-							GUILayout.Label(ShapeKeyMaster.CurrentLanguage["minExcitementThreshold"], UIUserOverrides.getLabelStyleOverride());
+							GUILayout.Label(ShapeKeyMaster.CurrentLanguage["minExcitementThreshold"]);
 							s.ExcitementMin = Mathf.RoundToInt(HorizontalSliderWithInputBox(s.ExcitementMin, 0, ShapeKeyMaster.MaxDeform.Value));
-							GUILayout.Label(ShapeKeyMaster.CurrentLanguage["defShapekeyDeformation"], UIUserOverrides.getLabelStyleOverride());
+							GUILayout.Label(ShapeKeyMaster.CurrentLanguage["defShapekeyDeformation"]);
 							s.Deform = Mathf.RoundToInt(HorizontalSliderWithInputBox(s.Deform, 0, ShapeKeyMaster.MaxDeform.Value));
-							GUILayout.Label(ShapeKeyMaster.CurrentLanguage["maxShapekeyDeformation"], UIUserOverrides.getLabelStyleOverride());
+							GUILayout.Label(ShapeKeyMaster.CurrentLanguage["maxShapekeyDeformation"]);
 							s.DeformMax = Mathf.RoundToInt(HorizontalSliderWithInputBox(s.DeformMax, s.DeformMin, ShapeKeyMaster.MaxDeform.Value));
-							GUILayout.Label(ShapeKeyMaster.CurrentLanguage["minShapekeyDeformation"], UIUserOverrides.getLabelStyleOverride());
+							GUILayout.Label(ShapeKeyMaster.CurrentLanguage["minShapekeyDeformation"]);
 							s.DeformMin = Mathf.RoundToInt(HorizontalSliderWithInputBox(s.DeformMin, 0, s.DeformMax));
 							break;
 
 						default:
-							GUILayout.Label(ShapeKeyMaster.CurrentLanguage["shapekeyDeformation"], UIUserOverrides.getLabelStyleOverride());
+							GUILayout.Label(ShapeKeyMaster.CurrentLanguage["shapekeyDeformation"]);
 							s.Deform = Mathf.RoundToInt(HorizontalSliderWithInputBox(s.Deform, 0, ShapeKeyMaster.MaxDeform.Value));
 							break;
 					}
 
 					GUILayout.BeginHorizontal(style);
 
-					if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["openSlotCondMenu"], UIUserOverrides.getButtonStyleOverride()))
+					if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["openSlotCondMenu"]))
 					{
 						_openSlotConditions = s.Id;
 						return;
 					}
 
-					s.ConditionalsToggle = GUILayout.Toggle(s.ConditionalsToggle, ShapeKeyMaster.CurrentLanguage["enableConditionals"], UIUserOverrides.getToggleStyleOverride());
+					s.ConditionalsToggle = GUILayout.Toggle(s.ConditionalsToggle, ShapeKeyMaster.CurrentLanguage["enableConditionals"]);
 
 					GUILayout.FlexibleSpace();
 
-					if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["rename"], UIUserOverrides.getButtonStyleOverride()))
+					if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["rename"]))
 					{
 						_openRenameMenu = s.Id;
 						return;
 					}
 
-					if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["delete"], UIUserOverrides.getButtonStyleOverride()))
+					if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["delete"]))
 					{
 						SkDatabase.Remove(s);
 						return;
@@ -1070,9 +1074,9 @@ namespace ShapeKeyMaster.GUI
 				else
 				{
 					GUILayout.BeginHorizontal(_sections);
-					GUILayout.Label(s.EntryName, UIUserOverrides.getLabelStyleOverride());
+					GUILayout.Label(s.EntryName);
 					GUILayout.FlexibleSpace();
-					if (GUILayout.Button("☰", UIUserOverrides.getButtonStyleOverride()))
+					if (GUILayout.Button("☰"))
 					{
 						s.Collapsed = !s.Collapsed;
 					}
@@ -1089,15 +1093,15 @@ namespace ShapeKeyMaster.GUI
 
 			GUILayout.BeginHorizontal();
 
-			GUILayout.Label($"{s.EntryName}: {ShapeKeyMaster.CurrentLanguage["selectShapekey"]}", UIUserOverrides.getLabelStyleOverride());
+			GUILayout.Label($"{s.EntryName}: {ShapeKeyMaster.CurrentLanguage["selectShapekey"]}");
 
 			GUILayout.FlexibleSpace();
 
-			GUILayout.Label(ShapeKeyMaster.CurrentLanguage["rclickToBlacklist"], UIUserOverrides.getLabelStyleOverride());
+			GUILayout.Label(ShapeKeyMaster.CurrentLanguage["rclickToBlacklist"]);
 
 			GUILayout.EndHorizontal();
 
-			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["finish"], UIUserOverrides.getButtonStyleOverride()))
+			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["finish"]))
 			{
 				_openSkMenu = Guid.Empty;
 				_oldSkMenuFilter = _filter;
@@ -1107,7 +1111,7 @@ namespace ShapeKeyMaster.GUI
 				_filter = "";
 			}
 
-			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["none"], UIUserOverrides.getButtonStyleOverride()))
+			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["none"]))
 			{
 				_openSkMenu = Guid.Empty;
 				_oldSkMenuFilter = _filter;
@@ -1176,7 +1180,7 @@ namespace ShapeKeyMaster.GUI
 					//Header for category
 					GUILayout.BeginHorizontal(_sections2);
 					GUILayout.FlexibleSpace();
-					GUILayout.Label(ShapeKeyMaster.CurrentLanguage[group.Key], UIUserOverrides.getLabelStyleOverride());
+					GUILayout.Label(ShapeKeyMaster.CurrentLanguage[group.Key]);
 					GUILayout.FlexibleSpace();
 					GUILayout.EndHorizontal();
 
@@ -1230,11 +1234,11 @@ namespace ShapeKeyMaster.GUI
 		{
 			DisplaySearchMenu(true);
 
-			GUILayout.Label($"{s.EntryName} {ShapeKeyMaster.CurrentLanguage["selectMaid"]}", UIUserOverrides.getLabelStyleOverride());
+			GUILayout.Label($"{s.EntryName} {ShapeKeyMaster.CurrentLanguage["selectMaid"]}");
 
 			GUILayout.BeginHorizontal(_sections2);
 
-			s.Maid = GUILayout.TextField(s.Maid, UIUserOverrides.getTextFieldStyleOverride(), GUILayout.Width(200));
+			s.Maid = GUILayout.TextField(s.Maid, GUILayout.Width(200));
 
 			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["finish"], GUILayout.Width(80)))
 			{
@@ -1243,7 +1247,7 @@ namespace ShapeKeyMaster.GUI
 
 			GUILayout.EndHorizontal();
 
-			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["none"], UIUserOverrides.getButtonStyleOverride()))
+			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["none"]))
 			{
 				_openMaidMenu = Guid.Empty;
 				s.Maid = "";
@@ -1260,7 +1264,7 @@ namespace ShapeKeyMaster.GUI
 					}
 				}
 
-				if (GUILayout.Button(mn, UIUserOverrides.getButtonStyleOverride()))
+				if (GUILayout.Button(mn))
 				{
 					_openMaidMenu = Guid.Empty;
 					s.Maid = mn;
@@ -1273,9 +1277,9 @@ namespace ShapeKeyMaster.GUI
 		{
 			DisplaySearchMenu(true);
 
-			GUILayout.Label(ShapeKeyMaster.CurrentLanguage["selectNewMaidGroup"], UIUserOverrides.getLabelStyleOverride());
+			GUILayout.Label(ShapeKeyMaster.CurrentLanguage["selectNewMaidGroup"]);
 
-			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["none"], UIUserOverrides.getButtonStyleOverride()))
+			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["none"]))
 			{
 				int i;
 
@@ -1304,7 +1308,7 @@ namespace ShapeKeyMaster.GUI
 					}
 				}
 
-				if (GUILayout.Button(mn, UIUserOverrides.getButtonStyleOverride()))
+				if (GUILayout.Button(mn))
 				{
 					var newKey = Guid.NewGuid();
 
@@ -1321,11 +1325,11 @@ namespace ShapeKeyMaster.GUI
 
 		private static void DisplayRenameMenu(ShapeKeyEntry s)
 		{
-			GUILayout.Label($"{ShapeKeyMaster.CurrentLanguage["nowRenaming"]} {s.EntryName}", UIUserOverrides.getLabelStyleOverride());
+			GUILayout.Label($"{ShapeKeyMaster.CurrentLanguage["nowRenaming"]} {s.EntryName}");
 
-			s.EntryName = GUILayout.TextField(s.EntryName, UIUserOverrides.getTextFieldStyleOverride());
+			s.EntryName = GUILayout.TextField(s.EntryName);
 
-			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["finish"], UIUserOverrides.getButtonStyleOverride()))
+			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["finish"]))
 			{
 				_openRenameMenu = Guid.Empty;
 			}
@@ -1337,20 +1341,20 @@ namespace ShapeKeyMaster.GUI
 
 			GUILayout.BeginHorizontal(_sections2);
 			GUILayout.FlexibleSpace();
-			GUILayout.Label(ShapeKeyMaster.CurrentLanguage["generalSettings"], UIUserOverrides.getLabelStyleOverride());
+			GUILayout.Label(ShapeKeyMaster.CurrentLanguage["generalSettings"]);
 			GUILayout.FlexibleSpace();
 			GUILayout.EndHorizontal();
 
-			s.ConditionalsToggle = GUILayout.Toggle(s.ConditionalsToggle, ShapeKeyMaster.CurrentLanguage["enableConditionals"], UIUserOverrides.getToggleStyleOverride());
+			s.ConditionalsToggle = GUILayout.Toggle(s.ConditionalsToggle, ShapeKeyMaster.CurrentLanguage["enableConditionals"]);
 
-			s.IgnoreCategoriesWithShapekey = GUILayout.Toggle(s.IgnoreCategoriesWithShapekey, ShapeKeyMaster.CurrentLanguage["ignoreCateWithKey"], UIUserOverrides.getToggleStyleOverride());
+			s.IgnoreCategoriesWithShapekey = GUILayout.Toggle(s.IgnoreCategoriesWithShapekey, ShapeKeyMaster.CurrentLanguage["ignoreCateWithKey"]);
 
-			s.DisableWhen = GUILayout.Toggle(s.DisableWhen, s.DisableWhen ? ShapeKeyMaster.CurrentLanguage["setShapekeyIf"] : ShapeKeyMaster.CurrentLanguage["doNotSetShapekeyIf"], UIUserOverrides.getToggleStyleOverride());
+			s.DisableWhen = GUILayout.Toggle(s.DisableWhen, s.DisableWhen ? ShapeKeyMaster.CurrentLanguage["setShapekeyIf"] : ShapeKeyMaster.CurrentLanguage["doNotSetShapekeyIf"]);
 
-			GUILayout.Label(ShapeKeyMaster.CurrentLanguage["disabledKeyDeform"], UIUserOverrides.getLabelStyleOverride());
+			GUILayout.Label(ShapeKeyMaster.CurrentLanguage["disabledKeyDeform"]);
 			s.DisabledDeform = GUILayout.HorizontalSlider(s.DisabledDeform, 0, ShapeKeyMaster.MaxDeform.Value);
 
-			s.WhenAll = GUILayout.Toggle(s.WhenAll, s.WhenAll ? ShapeKeyMaster.CurrentLanguage["ifAllSlotsEquipped"] : ShapeKeyMaster.CurrentLanguage["ifAnySlotEquipped"], UIUserOverrides.getToggleStyleOverride());
+			s.WhenAll = GUILayout.Toggle(s.WhenAll, s.WhenAll ? ShapeKeyMaster.CurrentLanguage["ifAllSlotsEquipped"] : ShapeKeyMaster.CurrentLanguage["ifAnySlotEquipped"]);
 
 			GUILayout.EndHorizontal();
 
@@ -1358,7 +1362,7 @@ namespace ShapeKeyMaster.GUI
 
 			GUILayout.BeginHorizontal(_sections2);
 			GUILayout.FlexibleSpace();
-			GUILayout.Label(ShapeKeyMaster.CurrentLanguage["slots"], UIUserOverrides.getLabelStyleOverride());
+			GUILayout.Label(ShapeKeyMaster.CurrentLanguage["slots"]);
 			GUILayout.FlexibleSpace();
 			GUILayout.EndHorizontal();
 
@@ -1371,7 +1375,7 @@ namespace ShapeKeyMaster.GUI
 					GUILayout.BeginHorizontal();
 				}
 
-				var temp = GUILayout.Toggle(s.SlotFlags.HasFlag(slot), ShapeKeyMaster.CurrentLanguage[SlotChecker.SlotToSlotList[slot].ToString()], UIUserOverrides.getToggleStyleOverride(), GUILayout.Width(100));
+				var temp = GUILayout.Toggle(s.SlotFlags.HasFlag(slot), ShapeKeyMaster.CurrentLanguage[SlotChecker.SlotToSlotList[slot].ToString()], GUILayout.Width(150));
 
 				if (i++ == 4)
 				{
@@ -1400,7 +1404,7 @@ namespace ShapeKeyMaster.GUI
 
 			GUILayout.BeginHorizontal(_sections2);
 			GUILayout.FlexibleSpace();
-			GUILayout.Label(ShapeKeyMaster.CurrentLanguage["menuFiles"], UIUserOverrides.getLabelStyleOverride());
+			GUILayout.Label(ShapeKeyMaster.CurrentLanguage["menuFiles"]);
 			GUILayout.FlexibleSpace();
 			GUILayout.EndHorizontal();
 
@@ -1412,27 +1416,27 @@ namespace ShapeKeyMaster.GUI
 			{
 				GUILayout.BeginHorizontal();
 
-				if (GUILayout.Button("X", UIUserOverrides.getButtonStyleOverride(), GUILayout.Width(20)))
+				if (GUILayout.Button("X", GUILayout.Width(20)))
 				{
 					s.MenuFileConditionals.Remove(menu);
 					return;
 				}
 
-				s.MenuFileConditionals[menu] = GUILayout.TextField(s.MenuFileConditionals[menu], UIUserOverrides.getTextFieldStyleOverride());
+				s.MenuFileConditionals[menu] = GUILayout.TextField(s.MenuFileConditionals[menu]);
 
 				GUILayout.EndHorizontal();
 			}
 
 			GUILayout.EndScrollView();
 
-			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["addNewMenuFile"], UIUserOverrides.getButtonStyleOverride()))
+			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["addNewMenuFile"]))
 			{
 				s.MenuFileConditionals[Guid.NewGuid()] = "";
 			}
 
 			GUILayout.EndVertical();
 
-			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["finish"], UIUserOverrides.getButtonStyleOverride()))
+			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["finish"]))
 			{
 				_openSlotConditions = Guid.Empty;
 			}
@@ -1442,13 +1446,13 @@ namespace ShapeKeyMaster.GUI
 		{
 			DisplaySearchMenu(true);
 
-			GUILayout.Label($"{ShapeKeyMaster.CurrentLanguage["renamingMaidGroup"]}: {s}", UIUserOverrides.getLabelStyleOverride());
+			GUILayout.Label($"{ShapeKeyMaster.CurrentLanguage["renamingMaidGroup"]}: {s}");
 
 			GUILayout.BeginHorizontal();
 
-			_maidGroupRename = GUILayout.TextField(_maidGroupRename, UIUserOverrides.getTextFieldStyleOverride());
+			_maidGroupRename = GUILayout.TextField(_maidGroupRename);
 
-			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["apply"], UIUserOverrides.getButtonStyleOverride()))
+			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["apply"]))
 			{
 				SkDatabase.AllShapekeyDictionary.Values.ToList().ForEach(sk =>
 				{
@@ -1475,7 +1479,7 @@ namespace ShapeKeyMaster.GUI
 					}
 				}
 
-				if (GUILayout.Button(mn, UIUserOverrides.getButtonStyleOverride()))
+				if (GUILayout.Button(mn))
 				{
 					SkDatabase.AllShapekeyDictionary.Values.ToList().ForEach(sk =>
 					{
@@ -1494,9 +1498,9 @@ namespace ShapeKeyMaster.GUI
 
 		private static void DisplayExportMenu()
 		{
-			ShapeKeyMaster.HideInactiveMaids.Value = GUILayout.Toggle(ShapeKeyMaster.HideInactiveMaids.Value, ShapeKeyMaster.CurrentLanguage["hideInactiveMaids"], UIUserOverrides.getToggleStyleOverride());
+			ShapeKeyMaster.HideInactiveMaids.Value = GUILayout.Toggle(ShapeKeyMaster.HideInactiveMaids.Value, ShapeKeyMaster.CurrentLanguage["hideInactiveMaids"]);
 
-			if (ShapeKeyMaster.HideInactiveMaids.Value == false && GUILayout.Button(ShapeKeyMaster.CurrentLanguage["all"], UIUserOverrides.getButtonStyleOverride()))
+			if (ShapeKeyMaster.HideInactiveMaids.Value == false && GUILayout.Button(ShapeKeyMaster.CurrentLanguage["all"]))
 			{
 				ShapeKeyMaster.pluginLogger.LogMessage(ShapeKeyMaster.CurrentLanguage["exportingAll"]);
 
@@ -1510,7 +1514,7 @@ namespace ShapeKeyMaster.GUI
 				ThingsToExport["global"] = false;
 			}
 
-			ThingsToExport["global"] = GUILayout.Toggle(ThingsToExport["global"], ShapeKeyMaster.CurrentLanguage["global"], UIUserOverrides.getToggleStyleOverride());
+			ThingsToExport["global"] = GUILayout.Toggle(ThingsToExport["global"], ShapeKeyMaster.CurrentLanguage["global"]);
 
 			foreach (var m in SkDatabase.ListOfMaidsWithKeys())
 			{
@@ -1521,12 +1525,12 @@ namespace ShapeKeyMaster.GUI
 					ThingsToExport[m] = false;
 				}
 
-				ThingsToExport[m] = GUILayout.Toggle(ThingsToExport[m], m, UIUserOverrides.getToggleStyleOverride());
+				ThingsToExport[m] = GUILayout.Toggle(ThingsToExport[m], m);
 			}
 
 			GUILayout.EndVertical();
 
-			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["done"], UIUserOverrides.getButtonStyleOverride()))
+			if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["done"]))
 			{
 				var selectionDataBase = new ShapeKeyDatabase();
 

--- a/ShapekeyMaster/GUI/UI.cs
+++ b/ShapekeyMaster/GUI/UI.cs
@@ -244,7 +244,7 @@ namespace ShapeKeyMaster.GUI
 				ShapeKeyMaster.SimpleMode.Value = GUILayout.Toggle(ShapeKeyMaster.SimpleMode.Value, ShapeKeyMaster.CurrentLanguage["simple"], UIUserOverrides.getToggleStyleOverride());
 				if (ShapeKeyMaster.SimpleMode.Value)
 				{
-					ShapeKeyMaster.SimpleMode_ShowMoreFuntions.Value = GUILayout.Toggle(ShapeKeyMaster.SimpleMode_ShowMoreFuntions.Value, ShapeKeyMaster.CurrentLanguage["showMoreFuntions"], UIUserOverrides.getToggleStyleOverride());
+					ShapeKeyMaster.SimpleMode_ShowMoreFunctions.Value = GUILayout.Toggle(ShapeKeyMaster.SimpleMode_ShowMoreFunctions.Value, ShapeKeyMaster.CurrentLanguage["showMoreFunctions"], UIUserOverrides.getToggleStyleOverride());
 				}
 
 				GUILayout.EndHorizontal();
@@ -719,7 +719,7 @@ namespace ShapeKeyMaster.GUI
 				}
 				s.ShapeKey = GUILayout.TextField(s.ShapeKey, UIUserOverrides.getTextFieldStyleOverride(), GUILayout.Width(ShapeKeyMaster.MinShapekeyNameTextboxWidth.Value));
 				s.Deform = Mathf.RoundToInt(HorizontalSliderWithInputBox(s.Deform, 0, ShapeKeyMaster.MaxDeform.Value));
-				if (!ShapeKeyMaster.SimpleMode_ShowMoreFuntions.Value)
+				if (!ShapeKeyMaster.SimpleMode_ShowMoreFunctions.Value)
 				{
 					if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["delete"], UIUserOverrides.getButtonStyleOverride()))
 					{
@@ -728,7 +728,7 @@ namespace ShapeKeyMaster.GUI
 				}
 				GUILayout.EndHorizontal();
 
-				if (ShapeKeyMaster.SimpleMode_ShowMoreFuntions.Value)
+				if (ShapeKeyMaster.SimpleMode_ShowMoreFunctions.Value)
 				{
 					GUILayout.BeginHorizontal(style);
 					if (GUILayout.Button(ShapeKeyMaster.CurrentLanguage["openSlotCondMenu"], UIUserOverrides.getButtonStyleOverride()))

--- a/ShapekeyMaster/GUI/UIToolbox.cs
+++ b/ShapekeyMaster/GUI/UIToolbox.cs
@@ -9,9 +9,9 @@ namespace ShapeKeyMaster.GUI
 {
 	internal class UiToolbox
 	{
-		public static int LastMouseButtonUp { private set; get; } = -1;
+        public static int LastMouseButtonUp { private set; get; } = -1;
 
-		public static void ChkMouseClick(Rect windowRect)
+        public static void ChkMouseClick(Rect windowRect)
 		{
 			LastMouseButtonUp = Input.GetMouseButtonUp(0) ? 0 : Input.GetMouseButtonUp(1) ? 1 : Input.GetMouseButtonUp(2) ? 2 : -1;
 
@@ -36,7 +36,7 @@ namespace ShapeKeyMaster.GUI
 
 		internal static float FloatField(float initialVal, float min = 0, float max = 100)
 		{
-			var stringReturn = GUILayout.TextField(initialVal.ToString("0"), GUILayout.Width(75));
+            var stringReturn = GUILayout.TextField(initialVal.ToString("0"), UIUserOverrides.getTextFieldStyleOverride(), GUILayout.Width(75));
 			stringReturn = NotNumPeriod.Replace(stringReturn, "");
 			stringReturn = stringReturn.IsNullOrWhiteSpace() ? "0" : stringReturn;
 
@@ -45,33 +45,33 @@ namespace ShapeKeyMaster.GUI
 
 		internal static float HorizontalSliderWithInputBox(float initialVal, float min = 0, float max = 100, string label = null, bool doButtons = true)
 		{
-			GUILayout.BeginHorizontal();
+            GUILayout.BeginHorizontal();
 
 			if (label.IsNullOrWhiteSpace() == false)
 			{
-				GUILayout.Label(label);
+				GUILayout.Label(label, UIUserOverrides.getLabelStyleOverride());
 			}
 
-			if (GUILayout.Button("0"))
+			if (GUILayout.Button("0", UIUserOverrides.getButtonStyleOverride()))
 			{
 				initialVal = 0;
 			}
 
-			initialVal = GUILayout.HorizontalSlider(initialVal, min, max, GUILayout.MaxWidth(9999));
+			initialVal = GUILayout.HorizontalSlider(initialVal, min, max, UIUserOverrides.getSliderStyleOverride(), UIUserOverrides.getSliderThumbStyleOverride(), GUILayout.MaxWidth(9999));
 
-			if (doButtons)
+            if (doButtons)
 			{
 				GUILayout.BeginHorizontal();
 
 				GUILayout.FlexibleSpace();
 
-				if (GUILayout.Button("<"))
+				if (GUILayout.Button("<", UIUserOverrides.getButtonStyleOverride()))
 				{
 					var addition = initialVal - 1;
 					initialVal = Math.Max(addition, min);
 				}
 
-				if (GUILayout.Button(">"))
+				if (GUILayout.Button(">", UIUserOverrides.getButtonStyleOverride()))
 				{
 					var addition = initialVal + 1;
 					initialVal = Math.Min(addition, max);

--- a/ShapekeyMaster/GUI/UIToolbox.cs
+++ b/ShapekeyMaster/GUI/UIToolbox.cs
@@ -36,7 +36,7 @@ namespace ShapeKeyMaster.GUI
 
 		internal static float FloatField(float initialVal, float min = 0, float max = 100)
 		{
-			var stringReturn = GUILayout.TextField(initialVal.ToString("0"), UIUserOverrides.getTextFieldStyleOverride(), GUILayout.Width(75));
+			var stringReturn = GUILayout.TextField(initialVal.ToString("0"), GUILayout.Width(75));
 			stringReturn = NotNumPeriod.Replace(stringReturn, "");
 			stringReturn = stringReturn.IsNullOrWhiteSpace() ? "0" : stringReturn;
 
@@ -49,15 +49,15 @@ namespace ShapeKeyMaster.GUI
 
 			if (label.IsNullOrWhiteSpace() == false)
 			{
-				GUILayout.Label(label, UIUserOverrides.getLabelStyleOverride());
+				GUILayout.Label(label);
 			}
 
-			if (GUILayout.Button("0", UIUserOverrides.getButtonStyleOverride()))
+			if (GUILayout.Button("0"))
 			{
 				initialVal = 0;
 			}
 
-			initialVal = GUILayout.HorizontalSlider(initialVal, min, max, UIUserOverrides.getSliderStyleOverride(), UIUserOverrides.getSliderThumbStyleOverride(), GUILayout.MaxWidth(9999));
+			initialVal = GUILayout.HorizontalSlider(initialVal, min, max, GUILayout.MaxWidth(9999));
 
 			if (doButtons)
 			{
@@ -65,13 +65,13 @@ namespace ShapeKeyMaster.GUI
 
 				GUILayout.FlexibleSpace();
 
-				if (GUILayout.Button("<", UIUserOverrides.getButtonStyleOverride()))
+				if (GUILayout.Button("<"))
 				{
 					var addition = initialVal - 1;
 					initialVal = Math.Max(addition, min);
 				}
 
-				if (GUILayout.Button(">", UIUserOverrides.getButtonStyleOverride()))
+				if (GUILayout.Button(">"))
 				{
 					var addition = initialVal + 1;
 					initialVal = Math.Min(addition, max);

--- a/ShapekeyMaster/GUI/UIToolbox.cs
+++ b/ShapekeyMaster/GUI/UIToolbox.cs
@@ -9,9 +9,9 @@ namespace ShapeKeyMaster.GUI
 {
 	internal class UiToolbox
 	{
-        public static int LastMouseButtonUp { private set; get; } = -1;
+		public static int LastMouseButtonUp { private set; get; } = -1;
 
-        public static void ChkMouseClick(Rect windowRect)
+		public static void ChkMouseClick(Rect windowRect)
 		{
 			LastMouseButtonUp = Input.GetMouseButtonUp(0) ? 0 : Input.GetMouseButtonUp(1) ? 1 : Input.GetMouseButtonUp(2) ? 2 : -1;
 
@@ -36,7 +36,7 @@ namespace ShapeKeyMaster.GUI
 
 		internal static float FloatField(float initialVal, float min = 0, float max = 100)
 		{
-            var stringReturn = GUILayout.TextField(initialVal.ToString("0"), UIUserOverrides.getTextFieldStyleOverride(), GUILayout.Width(75));
+			var stringReturn = GUILayout.TextField(initialVal.ToString("0"), UIUserOverrides.getTextFieldStyleOverride(), GUILayout.Width(75));
 			stringReturn = NotNumPeriod.Replace(stringReturn, "");
 			stringReturn = stringReturn.IsNullOrWhiteSpace() ? "0" : stringReturn;
 
@@ -45,7 +45,7 @@ namespace ShapeKeyMaster.GUI
 
 		internal static float HorizontalSliderWithInputBox(float initialVal, float min = 0, float max = 100, string label = null, bool doButtons = true)
 		{
-            GUILayout.BeginHorizontal();
+			GUILayout.BeginHorizontal();
 
 			if (label.IsNullOrWhiteSpace() == false)
 			{
@@ -59,7 +59,7 @@ namespace ShapeKeyMaster.GUI
 
 			initialVal = GUILayout.HorizontalSlider(initialVal, min, max, UIUserOverrides.getSliderStyleOverride(), UIUserOverrides.getSliderThumbStyleOverride(), GUILayout.MaxWidth(9999));
 
-            if (doButtons)
+			if (doButtons)
 			{
 				GUILayout.BeginHorizontal();
 

--- a/ShapekeyMaster/GUI/UIUserOverrides.cs
+++ b/ShapekeyMaster/GUI/UIUserOverrides.cs
@@ -1,0 +1,109 @@
+﻿using BepInEx;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using UnityEngine;
+
+namespace ShapeKeyMaster.GUI
+{
+    internal static class UIUserOverrides
+    {
+        //internal GUIStyle _buttonStyleOverride;
+        //internal GUIStyle _labelStyleOverride;
+        //internal GUIStyle _textFieldStyleOverride;
+        //internal GUIStyle _toggleStyleOverride;
+        //internal GUIStyle _sliderStyleOverride;
+        //internal GUIStyle _sliderThumbStyleOverride;
+
+        internal static GUIStyle getButtonStyleOverride()
+        {
+            var buttonStyleOverride = new GUIStyle(UnityEngine.GUI.skin.button)
+            {
+                fontSize = ShapeKeyMaster.FontSize.Value
+            };
+            return buttonStyleOverride;
+        }
+
+        internal static GUIStyle getLabelStyleOverride()
+        {
+            var labelStyleOverride = new GUIStyle(UnityEngine.GUI.skin.label)
+            {
+                fontSize = ShapeKeyMaster.FontSize.Value
+            };
+            return labelStyleOverride;
+        }
+
+        internal static GUIStyle getTextFieldStyleOverride()
+        {
+            var textFieldStyleOverride = new GUIStyle(UnityEngine.GUI.skin.textField)
+            {
+                fontSize = ShapeKeyMaster.FontSize.Value
+            }; 
+            return textFieldStyleOverride;
+        }
+
+        internal static GUIStyle getToggleStyleOverride()
+        {
+            return new GUIStyle(UnityEngine.GUI.skin.toggle)
+            {
+                fontSize = ShapeKeyMaster.FontSize.Value
+            };
+        }
+
+        internal static GUIStyle getSliderStyleOverride()
+        {
+            var sliderStyleOverride = new GUIStyle(UnityEngine.GUI.skin.horizontalSlider)
+            {
+                fixedHeight = ShapeKeyMaster.SliderSize.Value
+            };
+            return sliderStyleOverride;
+        }
+
+        internal static GUIStyle getSliderThumbStyleOverride()
+        {
+            var sliderThumbStyleOverride = new GUIStyle(UnityEngine.GUI.skin.horizontalSliderThumb)
+            {
+                fixedHeight = ShapeKeyMaster.SliderSize.Value,
+                fixedWidth = ShapeKeyMaster.SliderSize.Value
+            };
+            return sliderThumbStyleOverride;
+        }
+
+        //internal UIUserOverrides()
+        //{
+        //    _buttonStyleOverride = new GUIStyle(UnityEngine.GUI.skin.button)
+        //    {
+        //        fontSize = ShapeKeyMaster.FontSize.Value
+        //    };
+
+        //    _labelStyleOverride = new GUIStyle(UnityEngine.GUI.skin.label)
+        //    {
+        //        fontSize = ShapeKeyMaster.FontSize.Value
+        //    };
+
+        //    _textFieldStyleOverride = new GUIStyle(UnityEngine.GUI.skin.textField)
+        //    {
+        //        fontSize = ShapeKeyMaster.FontSize.Value
+        //    };
+
+        //    _toggleStyleOverride = new GUIStyle(UnityEngine.GUI.skin.toggle)
+        //    {
+        //        fixedWidth = 0f,
+        //        fixedHeight = 0f,
+        //        fontSize = ShapeKeyMaster.FontSize.Value
+        //    };
+
+        //    _sliderStyleOverride = new GUIStyle(UnityEngine.GUI.skin.horizontalSlider)
+        //    {
+        //        fixedHeight = ShapeKeyMaster.SliderSize.Value
+        //    };
+
+        //    _sliderThumbStyleOverride = new GUIStyle(UnityEngine.GUI.skin.horizontalSliderThumb)
+        //    {
+        //        fixedHeight = ShapeKeyMaster.SliderSize.Value,
+        //        fixedWidth = ShapeKeyMaster.SliderSize.Value
+        //    };
+        //}
+    }
+}

--- a/ShapekeyMaster/GUI/UIUserOverrides.cs
+++ b/ShapekeyMaster/GUI/UIUserOverrides.cs
@@ -10,6 +10,23 @@ namespace ShapeKeyMaster.GUI
 	internal static class UIUserOverrides
 	{
 		private static Dictionary<string, GUIStyle> cache = new Dictionary<string, GUIStyle>();
+
+		private static GUISkin _CustomSkin = GUISkin.CreateInstance<GUISkin>();
+
+		internal static GUISkin CustomSkin { 
+			get 
+			{
+				_CustomSkin.button = getButtonStyleOverride();
+				_CustomSkin.label = getLabelStyleOverride();
+				_CustomSkin.toggle = getToggleStyleOverride();
+				_CustomSkin.textField = getTextFieldStyleOverride();
+				_CustomSkin.horizontalSlider = getSliderStyleOverride();
+				_CustomSkin.horizontalSliderThumb = getSliderThumbStyleOverride();
+				return _CustomSkin;
+			}
+			set { }
+		}
+
 		internal static GUIStyle getButtonStyleOverride()
 		{
 			GUIStyle buttonStyleOverride;

--- a/ShapekeyMaster/GUI/UIUserOverrides.cs
+++ b/ShapekeyMaster/GUI/UIUserOverrides.cs
@@ -7,103 +7,60 @@ using UnityEngine;
 
 namespace ShapeKeyMaster.GUI
 {
-    internal static class UIUserOverrides
-    {
-        //internal GUIStyle _buttonStyleOverride;
-        //internal GUIStyle _labelStyleOverride;
-        //internal GUIStyle _textFieldStyleOverride;
-        //internal GUIStyle _toggleStyleOverride;
-        //internal GUIStyle _sliderStyleOverride;
-        //internal GUIStyle _sliderThumbStyleOverride;
+	internal static class UIUserOverrides
+	{
+		internal static GUIStyle getButtonStyleOverride()
+		{
+			var buttonStyleOverride = new GUIStyle(UnityEngine.GUI.skin.button)
+			{
+				fontSize = ShapeKeyMaster.FontSize.Value
+			};
+			return buttonStyleOverride;
+		}
 
-        internal static GUIStyle getButtonStyleOverride()
-        {
-            var buttonStyleOverride = new GUIStyle(UnityEngine.GUI.skin.button)
-            {
-                fontSize = ShapeKeyMaster.FontSize.Value
-            };
-            return buttonStyleOverride;
-        }
+		internal static GUIStyle getLabelStyleOverride()
+		{
+			var labelStyleOverride = new GUIStyle(UnityEngine.GUI.skin.label)
+			{
+				fontSize = ShapeKeyMaster.FontSize.Value
+			};
+			return labelStyleOverride;
+		}
 
-        internal static GUIStyle getLabelStyleOverride()
-        {
-            var labelStyleOverride = new GUIStyle(UnityEngine.GUI.skin.label)
-            {
-                fontSize = ShapeKeyMaster.FontSize.Value
-            };
-            return labelStyleOverride;
-        }
+		internal static GUIStyle getTextFieldStyleOverride()
+		{
+			var textFieldStyleOverride = new GUIStyle(UnityEngine.GUI.skin.textField)
+			{
+				fontSize = ShapeKeyMaster.FontSize.Value
+			};
+			return textFieldStyleOverride;
+		}
 
-        internal static GUIStyle getTextFieldStyleOverride()
-        {
-            var textFieldStyleOverride = new GUIStyle(UnityEngine.GUI.skin.textField)
-            {
-                fontSize = ShapeKeyMaster.FontSize.Value
-            }; 
-            return textFieldStyleOverride;
-        }
+		internal static GUIStyle getToggleStyleOverride()
+		{
+			return new GUIStyle(UnityEngine.GUI.skin.toggle)
+			{
+				fontSize = ShapeKeyMaster.FontSize.Value
+			};
+		}
 
-        internal static GUIStyle getToggleStyleOverride()
-        {
-            return new GUIStyle(UnityEngine.GUI.skin.toggle)
-            {
-                fontSize = ShapeKeyMaster.FontSize.Value
-            };
-        }
+		internal static GUIStyle getSliderStyleOverride()
+		{
+			var sliderStyleOverride = new GUIStyle(UnityEngine.GUI.skin.horizontalSlider)
+			{
+				fixedHeight = ShapeKeyMaster.SliderSize.Value
+			};
+			return sliderStyleOverride;
+		}
 
-        internal static GUIStyle getSliderStyleOverride()
-        {
-            var sliderStyleOverride = new GUIStyle(UnityEngine.GUI.skin.horizontalSlider)
-            {
-                fixedHeight = ShapeKeyMaster.SliderSize.Value
-            };
-            return sliderStyleOverride;
-        }
-
-        internal static GUIStyle getSliderThumbStyleOverride()
-        {
-            var sliderThumbStyleOverride = new GUIStyle(UnityEngine.GUI.skin.horizontalSliderThumb)
-            {
-                fixedHeight = ShapeKeyMaster.SliderSize.Value,
-                fixedWidth = ShapeKeyMaster.SliderSize.Value
-            };
-            return sliderThumbStyleOverride;
-        }
-
-        //internal UIUserOverrides()
-        //{
-        //    _buttonStyleOverride = new GUIStyle(UnityEngine.GUI.skin.button)
-        //    {
-        //        fontSize = ShapeKeyMaster.FontSize.Value
-        //    };
-
-        //    _labelStyleOverride = new GUIStyle(UnityEngine.GUI.skin.label)
-        //    {
-        //        fontSize = ShapeKeyMaster.FontSize.Value
-        //    };
-
-        //    _textFieldStyleOverride = new GUIStyle(UnityEngine.GUI.skin.textField)
-        //    {
-        //        fontSize = ShapeKeyMaster.FontSize.Value
-        //    };
-
-        //    _toggleStyleOverride = new GUIStyle(UnityEngine.GUI.skin.toggle)
-        //    {
-        //        fixedWidth = 0f,
-        //        fixedHeight = 0f,
-        //        fontSize = ShapeKeyMaster.FontSize.Value
-        //    };
-
-        //    _sliderStyleOverride = new GUIStyle(UnityEngine.GUI.skin.horizontalSlider)
-        //    {
-        //        fixedHeight = ShapeKeyMaster.SliderSize.Value
-        //    };
-
-        //    _sliderThumbStyleOverride = new GUIStyle(UnityEngine.GUI.skin.horizontalSliderThumb)
-        //    {
-        //        fixedHeight = ShapeKeyMaster.SliderSize.Value,
-        //        fixedWidth = ShapeKeyMaster.SliderSize.Value
-        //    };
-        //}
-    }
+		internal static GUIStyle getSliderThumbStyleOverride()
+		{
+			var sliderThumbStyleOverride = new GUIStyle(UnityEngine.GUI.skin.horizontalSliderThumb)
+			{
+				fixedHeight = ShapeKeyMaster.SliderSize.Value,
+				fixedWidth = ShapeKeyMaster.SliderSize.Value
+			};
+			return sliderThumbStyleOverride;
+		}
+	}
 }

--- a/ShapekeyMaster/GUI/UIUserOverrides.cs
+++ b/ShapekeyMaster/GUI/UIUserOverrides.cs
@@ -9,58 +9,121 @@ namespace ShapeKeyMaster.GUI
 {
 	internal static class UIUserOverrides
 	{
+		private static Dictionary<string, GUIStyle> cache = new Dictionary<string, GUIStyle>();
 		internal static GUIStyle getButtonStyleOverride()
 		{
-			var buttonStyleOverride = new GUIStyle(UnityEngine.GUI.skin.button)
+			GUIStyle buttonStyleOverride;
+			if (!cache.TryGetValue("ButtonStyleOverride", out buttonStyleOverride))
 			{
-				fontSize = ShapeKeyMaster.FontSize.Value
-			};
-			return buttonStyleOverride;
+				buttonStyleOverride = new GUIStyle(UnityEngine.GUI.skin.button)
+				{
+					fontSize = ShapeKeyMaster.FontSize.Value
+				};
+				cache.Add("ButtonStyleOverride", buttonStyleOverride);
+				return buttonStyleOverride;
+			}
+			else 
+			{
+				buttonStyleOverride.fontSize = ShapeKeyMaster.FontSize.Value;
+				return buttonStyleOverride;
+			}
 		}
 
 		internal static GUIStyle getLabelStyleOverride()
 		{
-			var labelStyleOverride = new GUIStyle(UnityEngine.GUI.skin.label)
+			GUIStyle labelStyleOverride;
+			if (!cache.TryGetValue("LabelStyleOverride", out labelStyleOverride))
 			{
-				fontSize = ShapeKeyMaster.FontSize.Value
-			};
-			return labelStyleOverride;
+				labelStyleOverride = new GUIStyle(UnityEngine.GUI.skin.label)
+				{
+					fontSize = ShapeKeyMaster.FontSize.Value
+				};
+				cache.Add("LabelStyleOverride", labelStyleOverride);
+				return labelStyleOverride;
+			}
+			else
+			{
+				labelStyleOverride.fontSize = ShapeKeyMaster.FontSize.Value;
+				return labelStyleOverride;
+			}
 		}
 
 		internal static GUIStyle getTextFieldStyleOverride()
 		{
-			var textFieldStyleOverride = new GUIStyle(UnityEngine.GUI.skin.textField)
+			GUIStyle textFieldStyleOverride;
+			if (!cache.TryGetValue("TextFieldStyleOverride", out textFieldStyleOverride))
 			{
-				fontSize = ShapeKeyMaster.FontSize.Value
-			};
-			return textFieldStyleOverride;
+				textFieldStyleOverride = new GUIStyle(UnityEngine.GUI.skin.textField)
+				{
+					fontSize = ShapeKeyMaster.FontSize.Value
+				};
+				cache.Add("TextFieldStyleOverride", textFieldStyleOverride);
+				return textFieldStyleOverride;
+			}
+			else
+			{
+				textFieldStyleOverride.fontSize = ShapeKeyMaster.FontSize.Value;
+				return textFieldStyleOverride;
+			}
 		}
 
 		internal static GUIStyle getToggleStyleOverride()
 		{
-			return new GUIStyle(UnityEngine.GUI.skin.toggle)
+			GUIStyle toggleStyleOverride;
+			if (!cache.TryGetValue("ToggleStyleOverride", out toggleStyleOverride))
 			{
-				fontSize = ShapeKeyMaster.FontSize.Value
-			};
+				toggleStyleOverride = new GUIStyle(UnityEngine.GUI.skin.toggle)
+				{
+					fontSize = ShapeKeyMaster.FontSize.Value
+				};
+				cache.Add("ToggleStyleOverride", toggleStyleOverride);
+				return toggleStyleOverride;
+			}
+			else
+			{
+				toggleStyleOverride.fontSize = ShapeKeyMaster.FontSize.Value;
+				return toggleStyleOverride;
+			}
 		}
 
 		internal static GUIStyle getSliderStyleOverride()
 		{
-			var sliderStyleOverride = new GUIStyle(UnityEngine.GUI.skin.horizontalSlider)
+			GUIStyle sliderStyleOverride;
+			if (!cache.TryGetValue("SliderStyleOverride", out sliderStyleOverride))
 			{
-				fixedHeight = ShapeKeyMaster.SliderSize.Value
-			};
-			return sliderStyleOverride;
+				sliderStyleOverride = new GUIStyle(UnityEngine.GUI.skin.horizontalSlider)
+				{
+					fixedHeight = ShapeKeyMaster.SliderSize.Value
+				};
+				cache.Add("SliderStyleOverride", sliderStyleOverride);
+				return sliderStyleOverride;
+			}
+			else
+			{
+				sliderStyleOverride.fixedHeight = ShapeKeyMaster.SliderSize.Value;
+				return sliderStyleOverride;
+			}
 		}
 
 		internal static GUIStyle getSliderThumbStyleOverride()
 		{
-			var sliderThumbStyleOverride = new GUIStyle(UnityEngine.GUI.skin.horizontalSliderThumb)
+			GUIStyle sliderThumbStyleOverride;
+			if (!cache.TryGetValue("SliderThumbStyleOverride", out sliderThumbStyleOverride))
 			{
-				fixedHeight = ShapeKeyMaster.SliderSize.Value,
-				fixedWidth = ShapeKeyMaster.SliderSize.Value
-			};
-			return sliderThumbStyleOverride;
+				sliderThumbStyleOverride = new GUIStyle(UnityEngine.GUI.skin.horizontalSliderThumb)
+				{
+					fixedHeight = ShapeKeyMaster.SliderSize.Value,
+					fixedWidth = ShapeKeyMaster.SliderSize.Value
+				};
+				cache.Add("SliderThumbStyleOverride", sliderThumbStyleOverride);
+				return sliderThumbStyleOverride;
+			}
+			else
+			{
+				sliderThumbStyleOverride.fixedHeight = ShapeKeyMaster.SliderSize.Value;
+				sliderThumbStyleOverride.fixedWidth = ShapeKeyMaster.SliderSize.Value;
+				return sliderThumbStyleOverride;
+			}
 		}
 	}
 }

--- a/ShapekeyMaster/ShapeKeyMaster.cs
+++ b/ShapekeyMaster/ShapeKeyMaster.cs
@@ -45,14 +45,14 @@ namespace ShapeKeyMaster
 		internal static ConfigEntry<string> Language;
 
 		internal static ConfigEntry<int> FontSize;
-        internal static ConfigEntry<float> SliderSize;
-        internal static ConfigEntry<float> MinUIHeight;
-        internal static ConfigEntry<float> MinUIWidth;
+		internal static ConfigEntry<float> SliderSize;
+		internal static ConfigEntry<float> MinUIHeight;
+		internal static ConfigEntry<float> MinUIWidth;
 		internal static ConfigEntry<float> MinShapekeyNameTextboxWidth;
 		internal static ConfigEntry<string> DefaultUIPosition;
-        internal static ConfigEntry<bool> SimpleMode_ShowMoreFuntions;
+		internal static ConfigEntry<bool> SimpleMode_ShowMoreFuntions;
 
-        internal static ConfigEntry<bool> HotKeyEnabled;
+		internal static ConfigEntry<bool> HotKeyEnabled;
 		internal static ConfigEntry<KeyboardShortcut> HotKey;
 
 		internal static TranslationResource CurrentLanguage { get; private set; }
@@ -91,16 +91,16 @@ namespace ShapeKeyMaster
 			HideInactiveMaids = Config.Bind("UI", "2. Hide Inactive Maids", false, "In the maids view, maids that are not present or loaded are hidden from the menu options.");
 			EntriesPerPage = Config.Bind("UI", "3. Entries Per Page", 10, "How many entries to display per an entry page.");
 			Language = Config.Bind("UI", "4. Language", "english.json", new ConfigDescription("The language for SKM's UI.", acceptableValues));
-		
-			FontSize = Config.Bind("UI 2", "1. Font Size", 14, "Font size.");
-            SliderSize = Config.Bind("UI 2", "2. Slider Size", 16f, "Shapekey slider size");
-            MinUIHeight = Config.Bind("UI 2", "3. Minimum UI Height", 200f, "Minimum UI height in pixels.");
-            MinUIWidth = Config.Bind("UI 2", "4. Minimum UI Width", 500f, "Minimum UI width in pixels.");
-            MinShapekeyNameTextboxWidth = Config.Bind("UI 2", "5. Minimum Shapekey Name Textbox Width", 200f, "Sets the minimum shapekey name textbox width in pixels. Wider shapekey name textbox will shorten the shapekey slider.");
-            DefaultUIPosition = Config.Bind("UI 2", "6. Default UI Position", "Default", new ConfigDescription("UI default position. Available Positions: \"TopLeft\", \"TopRight\", \"BottomLeft\", \"BottomRight\", \"Center\", \"Default\". If the top left corner of the UI exceeds screen boundaries, the UI postion will be set to \"Default\"", acceptableDefaultUIPositionList));
-            SimpleMode_ShowMoreFuntions = Config.Bind("UI 2", "7. Simple Mode - Show More Functions", true, "Show row under shapekey containing more functions, such as conditions setup, conditions toggle, copy shapekey.");
 
-            Language.SettingChanged += (e, s) =>
+			FontSize = Config.Bind("UI 2", "1. Font Size", 14, "Font size.");
+			SliderSize = Config.Bind("UI 2", "2. Slider Size", 16f, "Shapekey slider size");
+			MinUIHeight = Config.Bind("UI 2", "3. Minimum UI Height", 200f, "Minimum UI height in pixels.");
+			MinUIWidth = Config.Bind("UI 2", "4. Minimum UI Width", 500f, "Minimum UI width in pixels.");
+			MinShapekeyNameTextboxWidth = Config.Bind("UI 2", "5. Minimum Shapekey Name Textbox Width", 200f, "Sets the minimum shapekey name textbox width in pixels. Wider shapekey name textbox will shorten the shapekey slider.");
+			DefaultUIPosition = Config.Bind("UI 2", "6. Default UI Position", "Default", new ConfigDescription("UI default position. Available Positions: \"TopLeft\", \"TopRight\", \"BottomLeft\", \"BottomRight\", \"Center\", \"Default\". If the top left corner of the UI exceeds screen boundaries, the UI postion will be set to \"Default\"", acceptableDefaultUIPositionList));
+			SimpleMode_ShowMoreFuntions = Config.Bind("UI 2", "7. Simple Mode - Show More Functions", true, "Show row under shapekey containing more functions, such as conditions setup, conditions toggle, copy shapekey.");
+
+			Language.SettingChanged += (e, s) =>
 			{
 				CurrentLanguage = new TranslationResource(Paths.ConfigPath + "\\ShapekeyMaster\\" + Language.Value);
 			};
@@ -238,7 +238,7 @@ namespace ShapeKeyMaster
 				ObjectCreationHandling = ObjectCreationHandling.Replace
 			};
 
-			
+
 			return jsonObject.ToObject<ShapeKeyDatabase>();
 		}
 

--- a/ShapekeyMaster/ShapeKeyMaster.cs
+++ b/ShapekeyMaster/ShapeKeyMaster.cs
@@ -50,7 +50,7 @@ namespace ShapeKeyMaster
 		internal static ConfigEntry<float> MinUIWidth;
 		internal static ConfigEntry<float> MinShapekeyNameTextboxWidth;
 		internal static ConfigEntry<string> DefaultUIPosition;
-		internal static ConfigEntry<bool> SimpleMode_ShowMoreFuntions;
+		internal static ConfigEntry<bool> SimpleMode_ShowMoreFunctions;
 
 		internal static ConfigEntry<bool> HotKeyEnabled;
 		internal static ConfigEntry<KeyboardShortcut> HotKey;
@@ -98,7 +98,7 @@ namespace ShapeKeyMaster
 			MinUIWidth = Config.Bind("UI 2", "4. Minimum UI Width", 500f, "Minimum UI width in pixels.");
 			MinShapekeyNameTextboxWidth = Config.Bind("UI 2", "5. Minimum Shapekey Name Textbox Width", 200f, "Sets the minimum shapekey name textbox width in pixels. Wider shapekey name textbox will shorten the shapekey slider.");
 			DefaultUIPosition = Config.Bind("UI 2", "6. Default UI Position", "Default", new ConfigDescription("UI default position. Available Positions: \"TopLeft\", \"TopRight\", \"BottomLeft\", \"BottomRight\", \"Center\", \"Default\". If the top left corner of the UI exceeds screen boundaries, the UI postion will be set to \"Default\"", acceptableDefaultUIPositionList));
-			SimpleMode_ShowMoreFuntions = Config.Bind("UI 2", "7. Simple Mode - Show More Functions", true, "Show row under shapekey containing more functions, such as conditions setup, conditions toggle, copy shapekey.");
+			SimpleMode_ShowMoreFunctions = Config.Bind("UI 2", "7. Simple Mode - Show More Functions", true, "Show row under shapekey containing more functions, such as conditions setup, conditions toggle, copy shapekey.");
 
 			Language.SettingChanged += (e, s) =>
 			{

--- a/ShapekeyMaster/ShapeKeyMaster.cs
+++ b/ShapekeyMaster/ShapeKeyMaster.cs
@@ -44,7 +44,15 @@ namespace ShapeKeyMaster
 		internal static ConfigEntry<int> EntriesPerPage;
 		internal static ConfigEntry<string> Language;
 
-		internal static ConfigEntry<bool> HotKeyEnabled;
+		internal static ConfigEntry<int> FontSize;
+        internal static ConfigEntry<float> SliderSize;
+        internal static ConfigEntry<float> MinUIHeight;
+        internal static ConfigEntry<float> MinUIWidth;
+		internal static ConfigEntry<float> MinShapekeyNameTextboxWidth;
+		internal static ConfigEntry<string> DefaultUIPosition;
+        internal static ConfigEntry<bool> SimpleMode_ShowMoreFuntions;
+
+        internal static ConfigEntry<bool> HotKeyEnabled;
 		internal static ConfigEntry<KeyboardShortcut> HotKey;
 
 		internal static TranslationResource CurrentLanguage { get; private set; }
@@ -73,6 +81,7 @@ namespace ShapeKeyMaster
 			}
 
 			var acceptableValues = new AcceptableValueList<string>(translationFiles);
+			var acceptableDefaultUIPositionList = new AcceptableValueList<string>("TopLeft", "TopRight", "BottomLeft", "BottomRight", "Center", "Default");
 
 			MaxDeform = Config.Bind("General", "1. Max Deformation", 100f, "The max limit of the sliders in UI.");
 			AutoSave = Config.Bind("General", "2. AutoSave", true, "Will the config be saved automatically at set points.");
@@ -82,8 +91,16 @@ namespace ShapeKeyMaster
 			HideInactiveMaids = Config.Bind("UI", "2. Hide Inactive Maids", false, "In the maids view, maids that are not present or loaded are hidden from the menu options.");
 			EntriesPerPage = Config.Bind("UI", "3. Entries Per Page", 10, "How many entries to display per an entry page.");
 			Language = Config.Bind("UI", "4. Language", "english.json", new ConfigDescription("The language for SKM's UI.", acceptableValues));
+		
+			FontSize = Config.Bind("UI 2", "1. Font Size", 14, "Font size.");
+            SliderSize = Config.Bind("UI 2", "2. Slider Size", 16f, "Shapekey slider size");
+            MinUIHeight = Config.Bind("UI 2", "3. Minimum UI Height", 200f, "Minimum UI height in pixels.");
+            MinUIWidth = Config.Bind("UI 2", "4. Minimum UI Width", 500f, "Minimum UI width in pixels.");
+            MinShapekeyNameTextboxWidth = Config.Bind("UI 2", "5. Minimum Shapekey Name Textbox Width", 200f, "Sets the minimum shapekey name textbox width in pixels. Wider shapekey name textbox will shorten the shapekey slider.");
+            DefaultUIPosition = Config.Bind("UI 2", "6. Default UI Position", "Default", new ConfigDescription("UI default position. Available Positions: \"TopLeft\", \"TopRight\", \"BottomLeft\", \"BottomRight\", \"Center\", \"Default\". If the top left corner of the UI exceeds screen boundaries, the UI postion will be set to \"Default\"", acceptableDefaultUIPositionList));
+            SimpleMode_ShowMoreFuntions = Config.Bind("UI 2", "7. Simple Mode - Show More Functions", true, "Show row under shapekey containing more functions, such as conditions setup, conditions toggle, copy shapekey.");
 
-			Language.SettingChanged += (e, s) =>
+            Language.SettingChanged += (e, s) =>
 			{
 				CurrentLanguage = new TranslationResource(Paths.ConfigPath + "\\ShapekeyMaster\\" + Language.Value);
 			};

--- a/ShapekeyMaster/ShapeKeyUpdate.cs
+++ b/ShapekeyMaster/ShapeKeyUpdate.cs
@@ -215,7 +215,7 @@ namespace ShapeKeyMaster
 		public class UpdateKeysOrder : IShapeKeyWorkOrder, IEquatable<UpdateKeysOrder>
 		{
 #if DEBUG
-			private static Random rander = new Random();
+			private static System.Random rander = new System.Random();
 
 			public readonly string ID;
 #endif

--- a/ShapekeyMaster/ShapeKeyUpdate.cs
+++ b/ShapekeyMaster/ShapeKeyUpdate.cs
@@ -246,7 +246,7 @@ namespace ShapeKeyMaster
 						.ForEach(keyVal =>
 							{
 #if DEBUG
-							ShapeKeyMaster.pluginLogger.LogDebug($"{ID} is updating mesh for category: {keyVal.Key.Category} | Maid: {keyVal.Key.bodyskin.body.maid.status.fullNameJpStyle}");
+								ShapeKeyMaster.pluginLogger.LogDebug($"{ID} is updating mesh for category: {keyVal.Key.Category} | Maid: {keyVal.Key.bodyskin.body.maid.status.fullNameJpStyle}");
 #endif
 
 								keyVal.Key.FixBlendValues();

--- a/ShapekeyMaster/ShapekeyMaster.csproj
+++ b/ShapekeyMaster/ShapekeyMaster.csproj
@@ -36,6 +36,7 @@
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="GUI\UIUserOverrides.cs" />
     <Compile Include="ShapeKeyBlacklist.cs" />
     <Compile Include="ShapeKeyUpdate.cs" />
     <Compile Include="CategorySlotHandler.cs" />
@@ -64,7 +65,7 @@
       <HintPath>..\packages\BepInEx.BaseLib.5.4.21\lib\net35\BepInEx.dll</HintPath>
     </Reference>
     <Reference Include="COM3D2.API">
-      <HintPath>..\..\..\..\Desktop\Game Related Files\Meido Related Stuff\Meido Assemblies\COM Assemblies\Resources\COM3D2.API.dll</HintPath>
+      <HintPath>..\..\References\COM3D2.API.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.13.0.2\lib\net35\Newtonsoft.Json.dll</HintPath>
@@ -80,8 +81,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>del "G:\KISS\COM3D2Test\BepinEx\plugins\$(TargetFileName)"
-copy "$(TargetPath)" "G:\KISS\COM3D2Test\BepinEx\plugins"
-powershell start-process "G:\KISS\COM3D2Test\COM3D2x64.exe"</PostBuildEvent>
+    <PostBuildEvent>
+    </PostBuildEvent>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Added following configs for user overrides on UI component styles
1. Font size
2. Shapekey slider size
3. Minimum UI height
4. Minimum UI width
5. Shapekey name textbox width
6. UI default position
7. Toggle to hide condition row

Configs are placed in new section "UI 2" to avoid breaking existing ShapeKeyMaster.cfg
Updated GUI elements to be compatible with font size changes
Added another page manager row at the bottom of the shapekey list for easier paging when height of shapekey section exceeds UI height