### PR TITLE
Add ability to sort by and save order numbers

### DIFF
--- a/ShapekeyMaster/GUI/UIToolbox.cs
+++ b/ShapekeyMaster/GUI/UIToolbox.cs
@@ -43,6 +43,15 @@ namespace ShapeKeyMaster.GUI
 			return float.TryParse(stringReturn, out var floatReturn) ? Math.Min(max, Math.Max(floatReturn, min)) : initialVal;
 		}
 
+		internal static int IntField(int initialVal, int min = 0, int max = 100, int width = 75)
+		{
+			var stringReturn = GUILayout.TextField(initialVal.ToString("0"), GUILayout.Width(width));
+			stringReturn = NotNumPeriod.Replace(stringReturn, "");
+			stringReturn = stringReturn.IsNullOrWhiteSpace() ? "0" : stringReturn;
+
+			return int.TryParse(stringReturn, out var intReturn) ? Math.Min(max, Math.Max(intReturn, min)) : initialVal;
+		}
+
 		internal static float HorizontalSliderWithInputBox(float initialVal, float min = 0, float max = 100, string label = null, bool doButtons = true)
 		{
 			GUILayout.BeginHorizontal();
@@ -217,12 +226,13 @@ namespace ShapeKeyMaster.GUI
 			//Mode 1, entry name
 			//Mode 2, shapekey
 			//Mode 3, guid
+			//Mode 4, Order Number
 			public int Mode
 			{
 				get => mode;
 				set
 				{
-					if (value > 3 || value < 0)
+					if (value > 4 || value < 0)
 					{
 						mode = 0;
 					}
@@ -255,6 +265,10 @@ namespace ShapeKeyMaster.GUI
 
 					case 3:
 						result = shapekeyThing1.Id.CompareTo(shapekeyThing2.Id);
+						break;
+
+					case 4:
+						result = shapekeyThing1.OrderNum.Value.CompareTo(shapekeyThing2.OrderNum.Value);
 						break;
 
 					default:

--- a/ShapekeyMaster/ShapeKeyDatabase.cs
+++ b/ShapekeyMaster/ShapeKeyDatabase.cs
@@ -81,9 +81,40 @@ namespace ShapeKeyMaster
 				maidShapekeyDictionary[shapeKeyEntry.Maid].Add(shapeKeyEntry);
 			}
 
+			//Reassign order number to all shapekeys when:
+			//If any shapekey does not have an order number, OR
+			//If the list contains duplicate order numbers
+			foreach (var maidSkDb in maidShapekeyDictionary)
+			{
+				var maidSkList = maidSkDb.Value;
+				if (maidSkList.Any(s => !s.OrderNum.HasValue) 
+					|| maidSkList.Count != maidSkList.Select(s => s.OrderNum).Distinct().ToList().Count)
+				{
+					for (int i = 0; i < maidSkList.Count; i++)
+					{
+						maidSkList[i].OrderNum = null;
+						maidSkList[i].OrderNum = i + 1;
+					}
+				}
+			}
+
 			globalShapekeyDictionary = new Dictionary<Guid, ShapeKeyEntry>();
 
 			globalShapekeyDictionary = allShapekeyDictionary.Where(kv => string.IsNullOrEmpty(kv.Value.Maid)).ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+
+			//Reassign order number to all shapekeys when:
+			//If any shapekey does not have an order number, OR
+			//If the list contains duplicate order numbers
+			var globalSkList = globalShapekeyDictionary.Values.ToList();
+			if (globalSkList.Any(s => !s.OrderNum.HasValue) 
+				|| globalSkList.Count != globalSkList.Select(s => s.OrderNum).Distinct().ToList().Count)
+			{
+				for (int i = 0; i < globalSkList.Count; i++)
+				{
+					globalSkList[i].OrderNum = null;
+					globalSkList[i].OrderNum = i + 1;
+				}
+			}
 
 			if (ListOfActiveMorphs.Count > 0)
 			{
@@ -214,15 +245,89 @@ namespace ShapeKeyMaster
 
 		internal void Add(ShapeKeyEntry newVal)
 		{
+			var skList = string.IsNullOrEmpty(newVal.Maid) ? globalShapekeyDictionary.Values.ToList() :
+							maidShapekeyDictionary.ContainsKey(newVal.Maid) ? maidShapekeyDictionary[newVal.Maid] : null;
+			var count = skList?.Max(s => s.OrderNum);
+			newVal.OrderNum = null;
+			newVal.OrderNum = count.HasValue ? count + 1 : 1;
+
 			allShapekeyDictionary[newVal.Id] = newVal;
 			RefreshSubDictionaries();
 		}
 
 		internal void Remove(ShapeKeyEntry newVal)
 		{
+			var skList = string.IsNullOrEmpty(newVal.Maid) ? globalShapekeyDictionary.Values.ToList() : maidShapekeyDictionary[newVal.Maid];
+			var skAfter = skList.Where(s => s.OrderNum > newVal.OrderNum).ToList();
+			foreach (var s in skAfter) //Move all sks after removed key forward
+			{
+				var orderNum = s.OrderNum;
+				s.OrderNum = null;
+				s.OrderNum = orderNum -= 1;
+			}
+
 			allShapekeyDictionary.Remove(newVal.Id);
 			//newVal.Deform = 0;
 			RefreshSubDictionaries();
+		}
+
+		internal void Reorder_MoveForward(ShapeKeyEntry sk)
+		{
+			if (sk.OrderNum != 1) //First one in list
+			{
+				sk.OrderNum -= 1; //setter handles sorting
+			}
+		}
+
+		internal void Reorder_MoveBack(ShapeKeyEntry sk)
+		{
+			var skList = string.IsNullOrEmpty(sk.Maid) ? globalShapekeyDictionary.Values.ToList() : maidShapekeyDictionary[sk.Maid];
+			if (sk.OrderNum != skList.Count) //Last one in list
+			{
+				sk.OrderNum += 1; //setter handles sorting
+			}
+		}
+
+		internal int Reorder_Insert(ShapeKeyEntry sk, int newOrderNum) 
+		{
+			var oldOrderNum = sk.OrderNum.Value;
+			var skList = string.IsNullOrEmpty(sk.Maid) ? globalShapekeyDictionary.Values.ToList() : maidShapekeyDictionary[sk.Maid];
+			if (newOrderNum < 1)
+			{
+				newOrderNum = 1;
+			}
+			if (newOrderNum > skList.Count)
+			{
+				newOrderNum = skList.Count;
+			}
+			if (oldOrderNum != newOrderNum)
+			{
+				if (oldOrderNum < newOrderNum) //Move Back
+				{
+					var skBetween = skList.Where(s => oldOrderNum < s.OrderNum.Value && s.OrderNum.Value <= newOrderNum);
+					foreach (var s in skBetween)
+					{
+						var orderNum = s.OrderNum;
+						s.OrderNum = null;
+						s.OrderNum = orderNum -= 1;
+					}
+				}
+				if (oldOrderNum > newOrderNum) //Move Forward
+				{
+					var skBetween = skList.Where(s => newOrderNum <= s.OrderNum.Value && s.OrderNum.Value < oldOrderNum);
+					foreach (var s in skBetween)
+					{
+						var orderNum = s.OrderNum;
+						s.OrderNum = null;
+						s.OrderNum = orderNum += 1;
+					}
+				}
+				return newOrderNum;
+			}
+			else
+			{
+				return oldOrderNum;
+			}
 		}
 
 		internal void ConcatenateDictionary(Dictionary<Guid, ShapeKeyEntry> newDictionary, bool overwrite = false)

--- a/ShapekeyMaster/ShapeKeyEntry.cs
+++ b/ShapekeyMaster/ShapeKeyEntry.cs
@@ -1,4 +1,5 @@
-﻿using ShapeKeyMaster.GUI;
+﻿using Newtonsoft.Json;
+using ShapeKeyMaster.GUI;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -13,6 +14,32 @@ namespace ShapeKeyMaster
 		public Guid Id { get; }
 		public string EntryName { get; set; }
 		public DateTime CreationDate { get; set; }
+		[JsonIgnore]
+		private int? _OrderNum;
+		public int? OrderNum {
+			get
+			{ 
+				return _OrderNum;
+			}
+			set 
+			{
+				if (value == null)
+				{
+					_OrderNum = null;
+					return;
+				}
+
+				if (_OrderNum == null)
+				{
+					_OrderNum = value;
+					return;
+				}
+
+				_OrderNum = Ui.SkDatabase.Reorder_Insert(this, value.Value);
+			} 
+		}
+		[JsonIgnore]
+		public int? OrderNumTmp { get; set; }
 
 		private int enabled;
 		/// <summary>
@@ -435,13 +462,14 @@ namespace ShapeKeyMaster
 
 			//Main.@this.StartCoroutine(Animator);
 		}
-		
+
 		public object Clone()
 		{
 			var newClone = new ShapeKeyEntry(Guid.NewGuid(), maid)
 			{
 				enabled = enabled,
 				EntryName = EntryName.Clone() as string,
+				OrderNum = OrderNum,
 				deform = deform,
 				shapeKey = shapeKey,
 				animateWithExcitement = animateWithExcitement,

--- a/ShapekeyMaster/ShapeKeyMaster.cs
+++ b/ShapekeyMaster/ShapeKeyMaster.cs
@@ -43,6 +43,7 @@ namespace ShapeKeyMaster
 		internal static ConfigEntry<bool> HideInactiveMaids;
 		internal static ConfigEntry<int> EntriesPerPage;
 		internal static ConfigEntry<string> Language;
+		internal static ConfigEntry<string> DefaultSortingMethod;
 
 		internal static ConfigEntry<int> FontSize;
 		internal static ConfigEntry<float> SliderSize;
@@ -82,6 +83,7 @@ namespace ShapeKeyMaster
 
 			var acceptableValues = new AcceptableValueList<string>(translationFiles);
 			var acceptableDefaultUIPositionList = new AcceptableValueList<string>("TopLeft", "TopRight", "BottomLeft", "BottomRight", "Center", "Default");
+			var acceptableDefaultSortMethodList = new AcceptableValueList<string>("Date", "Name", "Shapekey", "Id", "Order Number");
 
 			MaxDeform = Config.Bind("General", "1. Max Deformation", 100f, "The max limit of the sliders in UI.");
 			AutoSave = Config.Bind("General", "2. AutoSave", true, "Will the config be saved automatically at set points.");
@@ -91,6 +93,7 @@ namespace ShapeKeyMaster
 			HideInactiveMaids = Config.Bind("UI", "2. Hide Inactive Maids", false, "In the maids view, maids that are not present or loaded are hidden from the menu options.");
 			EntriesPerPage = Config.Bind("UI", "3. Entries Per Page", 10, "How many entries to display per an entry page.");
 			Language = Config.Bind("UI", "4. Language", "english.json", new ConfigDescription("The language for SKM's UI.", acceptableValues));
+			DefaultSortingMethod = Config.Bind("UI", "5. Default Sorting Method", "Date", new ConfigDescription("The default sorting method.", acceptableDefaultSortMethodList));
 
 			FontSize = Config.Bind("UI 2", "1. Font Size", 14, "Font size.");
 			SliderSize = Config.Bind("UI 2", "2. Slider Size", 16f, "Shapekey slider size");


### PR DESCRIPTION
Add ability to sort by and save order numbers.

When ShapekeyMaster.JSON is loaded, all shapekey entries in their shapekey groups (global and maid) will be automatically assigned with order numbers if any entries has either duplicate or missing order number.

When sorting mode is by "order number" and "show more function" option is enabled, a set of buttons appear in the Condition row of each shapekey entry. 
The up and down arrow buttons moves the shapekey entry up or down by one position respectively. Clicking the order number button changes the button into a text field to allow the user to enter and insert the entry to the desired position. Clicking the check mark button, pressing the return key, or pressing the numpad enter key applies the change, clicking the X button cancels the edit and restores the buttons back to the arrow buttons.

Added configuration to choose the default sort method at start.

Changed page manager label to reflect shapekey count and sort order.