### PR TITLE
Optimize displaying the shape key select menu

### DIFF
--- a/ShapekeyMaster/GUI/UI.cs
+++ b/ShapekeyMaster/GUI/UI.cs
@@ -1,4 +1,4 @@
-﻿using BepInEx;
+using BepInEx;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -1223,43 +1223,43 @@ namespace ShapeKeyMaster.GUI
 				.OrderBy(r => r.Key)
 				.ToArray();
 
-			var bodyKeys = groupedKeys
-				.Where(r => r.Key.Equals("body"))
+			var bodyKeys = new HashSet<string>(groupedKeys
+				.Where(r => r.Key.Equals("body", StringComparison.Ordinal))
 				.SelectMany(r => r)
-				.Select(t => t.item2)
-				.ToList();
+				.Select(t => t.item2),
+				StringComparer.Ordinal);
 
-			var headKeys = groupedKeys
-				.Where(r => r.Key.Equals("head"))
+			var headKeys = new HashSet<string>(groupedKeys
+				.Where(r => r.Key.Equals("head", StringComparison.Ordinal))
 				.SelectMany(r => r)
-				.Select(t => t.item2)
-				.ToList();
+				.Select(t => t.item2),
+				StringComparer.Ordinal);
 
 			foreach (var group in groupedKeys)
 			{
 				totalGroupsWorked++;
 
-				var filteredList = group.ToList();
+				var filteredList = group.AsEnumerable();
 				
 				if (_filterCommonKeys)
 				{
-					if (group.Key.Equals("body") == false)
+					if (group.Key.Equals("body", StringComparison.Ordinal) == false)
 					{
-						filteredList = filteredList.Where(t => !bodyKeys.Contains(t.item2)).ToList();
+						filteredList = filteredList.Where(t => !bodyKeys.Contains(t.item2));
 					}
 
-					if (group.Key.Equals("head") == false)
+					if (group.Key.Equals("head", StringComparison.Ordinal) == false)
 					{
-						filteredList = filteredList.Where(t => !headKeys.Contains(t.item2)).ToList();
+						filteredList = filteredList.Where(t => !headKeys.Contains(t.item2));
 					}
 				}
 
 				if (_hideBlacklistedKeys)
 				{
-					filteredList = filteredList.Where(t => SkDatabase.BlacklistedShapeKeys.IsBlacklisted(t.item2) == false).ToList();
+					filteredList = filteredList.Where(t => SkDatabase.BlacklistedShapeKeys.IsBlacklisted(t.item2) == false);
 				}
 				
-				if (filteredList.Count > 0)
+				if (filteredList.Any())
 				{
 					if (columns++ == 0)
 					{

--- a/ShapekeyMaster/ShapeKeyBlacklist.cs
+++ b/ShapekeyMaster/ShapeKeyBlacklist.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using System.Collections.Generic;
 
 namespace ShapeKeyMaster
@@ -6,7 +6,7 @@ namespace ShapeKeyMaster
 	public class ShapeKeyBlacklist
 	{
 		[JsonProperty]
-		public List<string> Blacklist { get; private set; } = new List<string>
+		public HashSet<string> Blacklist { get; private set; } = new HashSet<string>
 		{
 			"arml",
 			"hara",


### PR DESCRIPTION
Displaying the shape key select menu causes the game's frame rate to drop below 20fps.

This PR optimizes displaying this menu by primarily removing unnecessary allocations when filtering the shape keys and using `HashSet<T>` instead of `List<T>` for checking if a key is contained within a filter.

The result is a frame rate of around 70~80fps with no filters and 80+fps depending on the filters used. This result indicates that the primary limiting factor for frame rate is now IMGUI.